### PR TITLE
CU-1vdwt52 Moved msg.rs of rates to andromeda_protocol package

### DIFF
--- a/contracts/andromeda_rates/src/contract.rs
+++ b/contracts/andromeda_rates/src/contract.rs
@@ -1,6 +1,8 @@
-use crate::msg::{ExecuteMsg, InstantiateMsg, PaymentsResponse, QueryMsg, RateInfo};
 use crate::state::{Config, CONFIG};
-use andromeda_protocol::error::ContractError;
+use andromeda_protocol::{
+    error::ContractError,
+    rates::{ExecuteMsg, InstantiateMsg, PaymentsResponse, QueryMsg, RateInfo},
+};
 use cosmwasm_std::{
     attr, entry_point, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
 };
@@ -64,8 +66,10 @@ fn query_payments(deps: Deps) -> StdResult<PaymentsResponse> {
 #[cfg(test)]
 mod tests {
     use crate::contract::{instantiate, query};
-    use crate::msg::{InstantiateMsg, PaymentsResponse, QueryMsg, RateInfo};
-    use andromeda_protocol::modules::{FlatRate, Rate};
+    use andromeda_protocol::{
+        modules::{FlatRate, Rate},
+        rates::{InstantiateMsg, PaymentsResponse, QueryMsg, RateInfo},
+    };
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
     use cosmwasm_std::{to_binary, Addr, Uint128};
 

--- a/contracts/andromeda_rates/src/lib.rs
+++ b/contracts/andromeda_rates/src/lib.rs
@@ -1,3 +1,2 @@
 pub mod contract;
-pub mod msg;
 pub mod state;

--- a/contracts/andromeda_rates/src/state.rs
+++ b/contracts/andromeda_rates/src/state.rs
@@ -1,4 +1,4 @@
-use crate::msg::RateInfo;
+use andromeda_protocol::rates::RateInfo;
 use cw_storage_plus::Item;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/packages/andromeda_protocol/src/lib.rs
+++ b/packages/andromeda_protocol/src/lib.rs
@@ -8,6 +8,7 @@ pub mod modules;
 pub mod operators;
 pub mod ownership;
 pub mod primitive;
+pub mod rates;
 pub mod receipt;
 pub mod response;
 pub mod splitter;

--- a/packages/andromeda_protocol/src/rates.rs
+++ b/packages/andromeda_protocol/src/rates.rs
@@ -1,4 +1,4 @@
-use andromeda_protocol::modules::Rate;
+use crate::modules::Rate;
 use cosmwasm_std::Addr;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Moved the `msg.rs` file of andromeda_rates to the package to be consistent with the rest of the contracts. 