### PR TITLE
Changed signatures of `is_operator` and `is_contract_owner` to use `&str` instead of `String`

### DIFF
--- a/contracts/andromeda_addresslist/src/contract.rs
+++ b/contracts/andromeda_addresslist/src/contract.rs
@@ -48,7 +48,7 @@ fn execute_add_address(
     address: String,
 ) -> Result<Response, ContractError> {
     require(
-        is_operator(deps.storage, info.sender.to_string())?,
+        is_operator(deps.storage, info.sender.as_str())?,
         ContractError::Unauthorized {},
     )?;
     add_address(deps.storage, &address)?;
@@ -65,7 +65,7 @@ fn execute_remove_address(
     address: String,
 ) -> Result<Response, ContractError> {
     require(
-        is_operator(deps.storage, info.sender.to_string())?,
+        is_operator(deps.storage, info.sender.as_str())?,
         ContractError::Unauthorized {},
     )?;
 
@@ -82,7 +82,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::IncludesAddress { address } => to_binary(&query_address(deps, &address)?),
         QueryMsg::ContractOwner {} => to_binary(&query_contract_owner(deps)?),
-        QueryMsg::IsOperator { address } => to_binary(&query_is_operator(deps, address)?),
+        QueryMsg::IsOperator { address } => to_binary(&query_is_operator(deps, &address)?),
     }
 }
 
@@ -124,7 +124,7 @@ mod tests {
         //input operator for test
 
         OPERATORS
-            .save(deps.as_mut().storage, operator.to_string(), &true)
+            .save(deps.as_mut().storage, operator, &true)
             .unwrap();
         CONTRACT_OWNER
             .save(deps.as_mut().storage, &info.sender)
@@ -177,7 +177,7 @@ mod tests {
 
         //save operator
         OPERATORS
-            .save(deps.as_mut().storage, operator.to_string(), &true)
+            .save(deps.as_mut().storage, operator, &true)
             .unwrap();
         CONTRACT_OWNER
             .save(deps.as_mut().storage, &info.sender)

--- a/contracts/andromeda_factory/src/contract.rs
+++ b/contracts/andromeda_factory/src/contract.rs
@@ -165,7 +165,7 @@ pub fn update_address(
 ) -> Result<Response, ContractError> {
     require(
         is_creator(&deps, symbol.clone(), info.sender.to_string())?
-            || is_contract_owner(deps.storage, info.sender.to_string())?,
+            || is_contract_owner(deps.storage, info.sender.as_str())?,
         ContractError::Unauthorized {},
     )?;
 
@@ -182,7 +182,7 @@ pub fn add_update_code_id(
     code_id: u64,
 ) -> Result<Response, ContractError> {
     require(
-        is_contract_owner(deps.storage, info.sender.to_string())?,
+        is_contract_owner(deps.storage, info.sender.as_str())?,
         ContractError::Unauthorized {},
     )?;
     store_code_id(deps.storage, code_id_key.clone(), code_id)?;
@@ -200,7 +200,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::GetAddress { symbol } => to_binary(&query_address(deps, symbol)?),
         QueryMsg::ContractOwner {} => to_binary(&query_contract_owner(deps)?),
         QueryMsg::CodeId { key } => to_binary(&query_code_id(deps, key)?),
-        QueryMsg::IsOperator { address } => to_binary(&query_is_operator(deps, address)?),
+        QueryMsg::IsOperator { address } => to_binary(&query_is_operator(deps, &address)?),
     }
 }
 

--- a/contracts/andromeda_primitive/src/contract.rs
+++ b/contracts/andromeda_primitive/src/contract.rs
@@ -52,7 +52,7 @@ pub fn execute_set_value(
     value: Primitive,
 ) -> Result<Response, ContractError> {
     require(
-        is_contract_owner(deps.storage, info.sender.to_string())?,
+        is_contract_owner(deps.storage, info.sender.as_str())?,
         ContractError::Unauthorized {},
     )?;
     if value.is_invalid() {
@@ -77,7 +77,7 @@ pub fn execute_delete_value(
     name: Option<String>,
 ) -> Result<Response, ContractError> {
     require(
-        is_contract_owner(deps.storage, info.sender.to_string())?,
+        is_contract_owner(deps.storage, info.sender.as_str())?,
         ContractError::Unauthorized {},
     )?;
     let name = get_name_or_default(&name);

--- a/contracts/andromeda_receipt/src/contract.rs
+++ b/contracts/andromeda_receipt/src/contract.rs
@@ -3,7 +3,7 @@ use crate::state::{
 };
 use andromeda_protocol::{
     error::ContractError,
-    operators::{execute_update_operators, query_is_operator, OPERATORS},
+    operators::{execute_update_operators, initialize_operators, query_is_operator},
     ownership::{execute_update_owner, query_contract_owner, CONTRACT_OWNER},
     receipt::{
         Config, ContractInfoResponse, ExecuteMsg, InstantiateMsg, QueryMsg, Receipt,
@@ -25,9 +25,7 @@ pub fn instantiate(
 ) -> Result<Response, ContractError> {
     store_config(deps.storage, &Config { minter: msg.minter })?;
     if let Some(operators) = msg.operators {
-        for operator in operators.iter() {
-            OPERATORS.save(deps.storage, operator.clone(), &true)?;
-        }
+        initialize_operators(deps.storage, operators)?;
     }
     CONTRACT_OWNER.save(deps.storage, &info.sender)?;
     Ok(Response::default()
@@ -95,7 +93,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::Receipt { receipt_id } => to_binary(&query_receipt(deps, receipt_id)?),
         QueryMsg::ContractInfo {} => to_binary(&query_config(deps)?),
         QueryMsg::ContractOwner {} => to_binary(&query_contract_owner(deps)?),
-        QueryMsg::IsOperator { address } => to_binary(&query_is_operator(deps, address)?),
+        QueryMsg::IsOperator { address } => to_binary(&query_is_operator(deps, &address)?),
     }
 }
 

--- a/contracts/andromeda_receipt/src/state.rs
+++ b/contracts/andromeda_receipt/src/state.rs
@@ -16,9 +16,7 @@ pub fn store_config(storage: &mut dyn Storage, config: &Config) -> StdResult<()>
 
 pub fn can_mint_receipt(storage: &dyn Storage, addr: &str) -> StdResult<bool> {
     let config = CONFIG.load(storage)?;
-    Ok(is_contract_owner(storage, addr.to_string())?
-        || addr.eq(&config.minter)
-        || is_operator(storage, addr.to_string())?)
+    Ok(is_contract_owner(storage, addr)? || addr.eq(&config.minter) || is_operator(storage, addr)?)
 }
 
 // increase receipt ID
@@ -57,7 +55,7 @@ mod tests {
     #[test]
     fn test_can_mint() {
         let minter = String::from("minter");
-        let moderator = String::from("moderator");
+        let operator = String::from("operator");
         let owner = String::from("owner");
         let anyone = String::from("anyone");
 
@@ -66,7 +64,7 @@ mod tests {
         };
         let mut deps = mock_dependencies(&[]);
         OPERATORS
-            .save(deps.as_mut().storage, moderator.clone(), &true)
+            .save(deps.as_mut().storage, &operator, &true)
             .unwrap();
 
         CONTRACT_OWNER
@@ -83,7 +81,7 @@ mod tests {
         let minter_resp = can_mint_receipt(deps.as_ref().storage, &minter).unwrap();
         assert!(minter_resp);
 
-        let moderator_resp = can_mint_receipt(deps.as_ref().storage, &moderator).unwrap();
-        assert!(moderator_resp);
+        let operator_resp = can_mint_receipt(deps.as_ref().storage, &operator).unwrap();
+        assert!(operator_resp);
     }
 }

--- a/contracts/andromeda_splitter/src/contract.rs
+++ b/contracts/andromeda_splitter/src/contract.rs
@@ -154,7 +154,7 @@ fn execute_update_recipients(
     recipients: Vec<AddressPercent>,
 ) -> Result<Response, ContractError> {
     require(
-        is_contract_owner(deps.storage, info.sender.to_string())?,
+        is_contract_owner(deps.storage, info.sender.as_str())?,
         ContractError::Unauthorized {},
     )?;
 
@@ -177,7 +177,7 @@ fn execute_update_lock(
     lock: bool,
 ) -> Result<Response, ContractError> {
     require(
-        is_contract_owner(deps.storage, info.sender.to_string())?,
+        is_contract_owner(deps.storage, info.sender.as_str())?,
         ContractError::Unauthorized {},
     )?;
     let mut splitter = SPLITTER.load(deps.storage)?;
@@ -197,7 +197,7 @@ fn execute_update_address_list(
     address_list: Option<AddressListModule>,
 ) -> Result<Response, ContractError> {
     require(
-        is_contract_owner(deps.storage, info.sender.to_string())?,
+        is_contract_owner(deps.storage, info.sender.as_str())?,
         ContractError::Unauthorized {},
     )?;
 
@@ -225,7 +225,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::GetSplitterConfig {} => to_binary(&query_splitter(deps)?),
         QueryMsg::ContractOwner {} => to_binary(&query_contract_owner(deps)?),
-        QueryMsg::IsOperator { address } => to_binary(&query_is_operator(deps, address)?),
+        QueryMsg::IsOperator { address } => to_binary(&query_is_operator(deps, &address)?),
     }
 }
 

--- a/contracts/andromeda_timelock/src/contract.rs
+++ b/contracts/andromeda_timelock/src/contract.rs
@@ -168,7 +168,7 @@ fn execute_update_address_list(
 ) -> Result<Response, ContractError> {
     let mut state = STATE.load(deps.storage)?;
     require(
-        is_contract_owner(deps.storage, info.sender.to_string())?,
+        is_contract_owner(deps.storage, info.sender.as_str())?,
         ContractError::Unauthorized {},
     )?;
 
@@ -192,7 +192,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::GetLockedFunds { address } => to_binary(&query_held_funds(deps, address)?),
         QueryMsg::GetTimelockConfig {} => to_binary(&query_config(deps)?),
         QueryMsg::ContractOwner {} => to_binary(&query_contract_owner(deps)?),
-        QueryMsg::IsOperator { address } => to_binary(&query_is_operator(deps, address)?),
+        QueryMsg::IsOperator { address } => to_binary(&query_is_operator(deps, &address)?),
     }
 }
 

--- a/packages/andromeda_protocol/src/modules/address_list.rs
+++ b/packages/andromeda_protocol/src/modules/address_list.rs
@@ -83,7 +83,7 @@ impl Module for AddressListModule {
 
         require(
             self.address.is_some() || (self.code_id.is_some() && self.operators.is_some()),
-            ContractError::Std(StdError::generic_err("Address list must include either a contract address or a code id and moderator list")),
+            ContractError::Std(StdError::generic_err("Address list must include either a contract address or a code id and operator list")),
         )?;
 
         Ok(true)

--- a/packages/andromeda_protocol/src/modules/receipt.rs
+++ b/packages/andromeda_protocol/src/modules/receipt.rs
@@ -70,7 +70,7 @@ impl Module for ReceiptModule {
         require(
             self.address.is_some() || (self.code_id.is_some() && self.operators.is_some()),
             ContractError::Std(StdError::generic_err(
-                "Receipt must include either a contract address or a code id and moderator list",
+                "Receipt must include either a contract address or a code id and operator list",
             )),
         )?;
 

--- a/packages/andromeda_protocol/src/operators.rs
+++ b/packages/andromeda_protocol/src/operators.rs
@@ -7,12 +7,12 @@ use cw_storage_plus::Map;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-pub const OPERATORS: Map<String, bool> = Map::new("operators");
+pub const OPERATORS: Map<&str, bool> = Map::new("operators");
 
 /// Helper function to query if a given address is a operator.
 ///
 /// Returns a boolean value indicating if the given address is a operator.
-pub fn is_operator(storage: &dyn Storage, addr: String) -> StdResult<bool> {
+pub fn is_operator(storage: &dyn Storage, addr: &str) -> StdResult<bool> {
     Ok(OPERATORS.may_load(storage, addr)?.is_some())
 }
 
@@ -22,7 +22,7 @@ pub fn execute_update_operators(
     operators: Vec<String>,
 ) -> Result<Response, ContractError> {
     require(
-        is_contract_owner(deps.storage, info.sender.to_string())?,
+        is_contract_owner(deps.storage, info.sender.as_str())?,
         ContractError::Unauthorized {},
     )?;
 
@@ -30,11 +30,11 @@ pub fn execute_update_operators(
         .keys(deps.storage, None, None, Order::Ascending)
         .collect();
     for key in keys.iter() {
-        OPERATORS.remove(deps.storage, String::from_utf8(key.clone())?);
+        OPERATORS.remove(deps.storage, &String::from_utf8(key.clone())?);
     }
 
     for x in operators.iter() {
-        OPERATORS.save(deps.storage, x.clone(), &true)?;
+        OPERATORS.save(deps.storage, &x, &true)?;
     }
 
     Ok(Response::new().add_attributes(vec![attr("action", "update_operators")]))
@@ -42,12 +42,12 @@ pub fn execute_update_operators(
 
 pub fn initialize_operators(storage: &mut dyn Storage, operators: Vec<String>) -> StdResult<()> {
     for operator in operators.iter() {
-        OPERATORS.save(storage, operator.clone(), &true)?;
+        OPERATORS.save(storage, &operator, &true)?;
     }
     Ok(())
 }
 
-pub fn query_is_operator(deps: Deps, addr: String) -> StdResult<IsOperatorResponse> {
+pub fn query_is_operator(deps: Deps, addr: &str) -> StdResult<IsOperatorResponse> {
     let operator = OPERATORS.may_load(deps.storage, addr)?;
     Ok(IsOperatorResponse {
         is_operator: operator.is_some(),
@@ -91,16 +91,16 @@ mod tests {
         let expected = Response::new().add_attributes(vec![attr("action", "update_operators")]);
         assert_eq!(resp, expected);
         //check
-        let query_resp = query_is_operator(deps.as_ref(), "operator_001".to_string()).unwrap();
+        let query_resp = query_is_operator(deps.as_ref(), "operator_001").unwrap();
         assert!(query_resp.is_operator);
 
         //update another operators
         let _ = execute_update_operators(deps.as_mut(), auth_info, vec!["another".to_string()])
             .unwrap();
         //check to be removed operator_000, operator_001
-        let query_resp = query_is_operator(deps.as_ref(), "operator_001".to_string()).unwrap();
+        let query_resp = query_is_operator(deps.as_ref(), "operator_001").unwrap();
         assert!(!query_resp.is_operator);
-        let query_resp = query_is_operator(deps.as_ref(), "operator_000".to_string()).unwrap();
+        let query_resp = query_is_operator(deps.as_ref(), "operator_000").unwrap();
         assert!(!query_resp.is_operator);
     }
 }

--- a/packages/andromeda_protocol/src/ownership.rs
+++ b/packages/andromeda_protocol/src/ownership.rs
@@ -23,7 +23,7 @@ pub fn execute_update_owner(
     new_owner: String,
 ) -> Result<Response, ContractError> {
     require(
-        is_contract_owner(deps.storage, &info.sender.to_string())?,
+        is_contract_owner(deps.storage, info.sender.as_str())?,
         ContractError::Unauthorized {},
     )?;
     //

--- a/packages/andromeda_protocol/src/ownership.rs
+++ b/packages/andromeda_protocol/src/ownership.rs
@@ -11,10 +11,9 @@ pub const CONTRACT_OWNER: Item<Addr> = Item::new("contractowner");
 /// Helper function to query if a given address is the current contract owner.
 ///
 /// Returns a boolean value indicating if the given address is the contract owner.
-pub fn is_contract_owner(storage: &dyn Storage, addr: String) -> StdResult<bool> {
+pub fn is_contract_owner(storage: &dyn Storage, addr: &str) -> StdResult<bool> {
     let owner = CONTRACT_OWNER.load(storage)?;
-
-    Ok(addr.eq(&owner))
+    Ok(addr == owner)
 }
 
 /// Updates the current contract owner. **Only executable by the current contract owner.**
@@ -24,7 +23,7 @@ pub fn execute_update_owner(
     new_owner: String,
 ) -> Result<Response, ContractError> {
     require(
-        is_contract_owner(deps.storage, info.sender.to_string())?,
+        is_contract_owner(deps.storage, &info.sender.to_string())?,
         ContractError::Unauthorized {},
     )?;
     //

--- a/packages/andromeda_protocol/src/receipt.rs
+++ b/packages/andromeda_protocol/src/receipt.rs
@@ -30,7 +30,7 @@ pub enum ExecuteMsg {
     StoreReceipt {
         receipt: Receipt,
     },
-    /// Edit a receipt by ID. Only executable by the assigned `minter` address or a valid `moderator`.
+    /// Edit a receipt by ID. Only executable by the assigned `minter` address or a valid `operator`.
     EditReceipt {
         receipt_id: Uint128,
         receipt: Receipt,


### PR DESCRIPTION
As title says, I noticed that we could slightly improve our code if we made this change. The benefit is that we can now remove a few unnecessary clones and in general the code is more ergonomic. 

I also noticed a few places where I missed renaming `moderator` to `operator` so I also did that here. 