### PR TITLE
CU-1u5yywn Added communication protocol to Rates contract

### DIFF
--- a/packages/andromeda_protocol/src/rates.rs
+++ b/packages/andromeda_protocol/src/rates.rs
@@ -1,4 +1,7 @@
-use crate::modules::Rate;
+use crate::{
+    communication::{AndromedaMsg, AndromedaQuery},
+    modules::Rate,
+};
 use cosmwasm_std::Addr;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -11,12 +14,14 @@ pub struct InstantiateMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
+    AndrReceive(AndromedaMsg),
     UpdateRates { rates: Vec<RateInfo> },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
+    AndrQuery(AndromedaQuery),
     Payments {},
 }
 


### PR DESCRIPTION
Since this contract has only a single `ExecuteMsg` and `QueryMsg`, I made those the default actions when receiving an `AndromedaMsg` or `AndromedaQuery`.