### PR TITLE
CU-1u5yywn Added communication protocol to anchor contract

### DIFF
--- a/contracts/andromeda_anchor/src/testing/tests.rs
+++ b/contracts/andromeda_anchor/src/testing/tests.rs
@@ -1,10 +1,16 @@
-use cosmwasm_std::{testing::{mock_dependencies, mock_env, mock_info}, Api, Coin, Uint128, Response, attr, SubMsg, CosmosMsg, WasmMsg, to_binary, coin};
-use cw20::Cw20ExecuteMsg;
-use andromeda_protocol::anchor::{AnchorMarketMsg, ExecuteMsg, InstantiateMsg, YourselfMsg};
 use crate::contract::{execute, instantiate};
 use crate::state::{CONFIG, POSITION};
 use crate::testing::mock_querier::mock_dependencies_custom;
-
+use andromeda_protocol::{
+    anchor::{AnchorMarketMsg, ExecuteMsg, InstantiateMsg, YourselfMsg},
+    communication::AndromedaMsg,
+};
+use cosmwasm_std::{
+    attr, coin,
+    testing::{mock_dependencies, mock_env, mock_info},
+    to_binary, Api, Coin, CosmosMsg, Response, SubMsg, Uint128, WasmMsg,
+};
+use cw20::Cw20ExecuteMsg;
 
 #[test]
 fn test_instantiate() {
@@ -15,7 +21,7 @@ fn test_instantiate() {
     let msg = InstantiateMsg {
         anchor_token: "anchor_token".to_string(),
         anchor_mint: "anchor_mint".to_string(),
-        stable_denom: "uusd".to_string()
+        stable_denom: "uusd".to_string(),
     };
     let res = instantiate(deps.as_mut(), env, info.clone(), msg.clone()).unwrap();
 
@@ -24,22 +30,35 @@ fn test_instantiate() {
     //checking
     let config = CONFIG.load(deps.as_ref().storage).unwrap();
 
-    assert_eq!(msg.anchor_token, deps.api.addr_humanize(&config.anchor_token).unwrap().to_string());
-    assert_eq!(msg.anchor_mint, deps.api.addr_humanize(&config.anchor_mint).unwrap().to_string());
+    assert_eq!(
+        msg.anchor_token,
+        deps.api
+            .addr_humanize(&config.anchor_token)
+            .unwrap()
+            .to_string()
+    );
+    assert_eq!(
+        msg.anchor_mint,
+        deps.api
+            .addr_humanize(&config.anchor_mint)
+            .unwrap()
+            .to_string()
+    );
     assert_eq!(msg.stable_denom, config.stable_denom);
 }
+
 #[test]
-fn test_deposit(){
-    let mut deps =mock_dependencies_custom(&[]);
-    let msg =InstantiateMsg{
+fn test_deposit() {
+    let mut deps = mock_dependencies_custom(&[]);
+    let msg = InstantiateMsg {
         anchor_token: "aust_token".to_string(),
         anchor_mint: "anchor_mint".to_string(),
-        stable_denom: "uusd".to_string()
+        stable_denom: "uusd".to_string(),
     };
     let info = mock_info("addr0000", &[]);
     let _res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
-    let msg =ExecuteMsg::Deposit {};
+    let msg = ExecuteMsg::Deposit {};
     let info = mock_info(
         "addr0000",
         &[Coin {
@@ -49,35 +68,34 @@ fn test_deposit(){
     );
     let env = mock_env();
     let res = execute(deps.as_mut(), env, info, msg).unwrap();
-    let expected_res = Response::new().add_submessage(
-        SubMsg::reply_on_success(
-            CosmosMsg::Wasm(
-                WasmMsg::Execute{
-                    contract_addr: "anchor_mint".to_string(),
-                    msg: to_binary( &AnchorMarketMsg::DepositStable{}).unwrap(),
-                    funds: vec![coin(1000000u128, "uusd")]
-                }),
-            1u64
-        )
-    ).add_attributes(vec![
-        attr("action", "deposit"),
-        attr("deposit_amount", "1000000")
-    ]);
-    assert_eq!(res,expected_res)
+    let expected_res = Response::new()
+        .add_submessage(SubMsg::reply_on_success(
+            CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: "anchor_mint".to_string(),
+                msg: to_binary(&AnchorMarketMsg::DepositStable {}).unwrap(),
+                funds: vec![coin(1000000u128, "uusd")],
+            }),
+            1u64,
+        ))
+        .add_attributes(vec![
+            attr("action", "deposit"),
+            attr("deposit_amount", "1000000"),
+        ]);
+    assert_eq!(res, expected_res)
 }
 
 #[test]
-fn test_withdraw(){
-    let mut deps =mock_dependencies_custom(&[]);
-    let msg =InstantiateMsg{
+fn test_withdraw() {
+    let mut deps = mock_dependencies_custom(&[]);
+    let msg = InstantiateMsg {
         anchor_token: "aust_token".to_string(),
         anchor_mint: "anchor_mint".to_string(),
-        stable_denom: "uusd".to_string()
+        stable_denom: "uusd".to_string(),
     };
     let info = mock_info("addr0000", &[]);
     let _res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
-    let msg =ExecuteMsg::Deposit {};
+    let msg = ExecuteMsg::Deposit {};
     let info = mock_info(
         "addr0000",
         &[Coin {
@@ -90,38 +108,117 @@ fn test_withdraw(){
     //set aust_amount to position manually
     let mut position = POSITION.load(&deps.storage, &1u128.to_be_bytes()).unwrap();
     position.aust_amount = Uint128::from(1000000u128);
-    POSITION.save(deps.as_mut().storage, &1u128.to_be_bytes(), &position).unwrap();
+    POSITION
+        .save(deps.as_mut().storage, &1u128.to_be_bytes(), &position)
+        .unwrap();
 
-    let msg = ExecuteMsg::Withdraw { position_idx: Uint128::from(1u128) };
+    let msg = ExecuteMsg::Withdraw {
+        position_idx: Uint128::from(1u128),
+    };
     let info = mock_info("addr0000", &[]);
-    let res = execute(deps.as_mut(), env.clone(),info.clone(),msg).unwrap();
-    
+    let res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+
     let expected_res = Response::new()
         .add_messages(vec![
-            CosmosMsg::Wasm(
-                    WasmMsg::Execute{
-                        contract_addr: "aust_token".to_string(),
-                        msg: to_binary( &Cw20ExecuteMsg::Send {
-                            contract: "anchor_mint".to_string(),
-                            amount: Uint128::from(1000000u128),
-                            msg: to_binary(&AnchorMarketMsg::RedeemStable {}).unwrap()
-                        }).unwrap(),
-                        funds: vec![]
-                    }),
-            CosmosMsg::Wasm(
-                WasmMsg::Execute{
-                    contract_addr: "cosmos2contract".to_string(),
-                    msg: to_binary( &ExecuteMsg::Yourself{
-                        yourself_msg: YourselfMsg::TransferUst { receiver: "addr0000".to_string() }
-                    }).unwrap(),
-                    funds: vec![]
-                }),
-        ]
-    ).add_attributes(
-        vec![
-            attr("action","withdraw"),
-            attr("position_idx", "1")
-        ]
-    );
-    assert_eq!(res,expected_res)
+            CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: "aust_token".to_string(),
+                msg: to_binary(&Cw20ExecuteMsg::Send {
+                    contract: "anchor_mint".to_string(),
+                    amount: Uint128::from(1000000u128),
+                    msg: to_binary(&AnchorMarketMsg::RedeemStable {}).unwrap(),
+                })
+                .unwrap(),
+                funds: vec![],
+            }),
+            CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: "cosmos2contract".to_string(),
+                msg: to_binary(&ExecuteMsg::Yourself {
+                    yourself_msg: YourselfMsg::TransferUst {
+                        receiver: "addr0000".to_string(),
+                    },
+                })
+                .unwrap(),
+                funds: vec![],
+            }),
+        ])
+        .add_attributes(vec![attr("action", "withdraw"), attr("position_idx", "1")]);
+    assert_eq!(res, expected_res)
 }
+
+#[test]
+fn test_andr_receive() {
+    let mut deps = mock_dependencies_custom(&[]);
+    let msg = InstantiateMsg {
+        anchor_token: "aust_token".to_string(),
+        anchor_mint: "anchor_mint".to_string(),
+        stable_denom: "uusd".to_string(),
+    };
+    let info = mock_info("addr0000", &[]);
+    let _res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    let msg = ExecuteMsg::AndrReceive(AndromedaMsg::Receive(None));
+    let info = mock_info(
+        "addr0000",
+        &[Coin {
+            denom: "uusd".to_string(),
+            amount: Uint128::from(1000000u128),
+        }],
+    );
+    let env = mock_env();
+    let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+    let expected_res = Response::new()
+        .add_submessage(SubMsg::reply_on_success(
+            CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: "anchor_mint".to_string(),
+                msg: to_binary(&AnchorMarketMsg::DepositStable {}).unwrap(),
+                funds: vec![coin(1000000u128, "uusd")],
+            }),
+            1u64,
+        ))
+        .add_attributes(vec![
+            attr("action", "deposit"),
+            attr("deposit_amount", "1000000"),
+        ]);
+    assert_eq!(res, expected_res);
+
+    //set aust_amount to position manually
+    let mut position = POSITION.load(&deps.storage, &1u128.to_be_bytes()).unwrap();
+    position.aust_amount = Uint128::from(1000000u128);
+    POSITION
+        .save(deps.as_mut().storage, &1u128.to_be_bytes(), &position)
+        .unwrap();
+
+    let msg = ExecuteMsg::AndrReceive(AndromedaMsg::Receive(Some(
+        to_binary(&Uint128::from(1u128)).unwrap(),
+    )));
+
+    let info = mock_info("addr0000", &[]);
+    let res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+
+    let expected_res = Response::new()
+        .add_messages(vec![
+            CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: "aust_token".to_string(),
+                msg: to_binary(&Cw20ExecuteMsg::Send {
+                    contract: "anchor_mint".to_string(),
+                    amount: Uint128::from(1000000u128),
+                    msg: to_binary(&AnchorMarketMsg::RedeemStable {}).unwrap(),
+                })
+                .unwrap(),
+                funds: vec![],
+            }),
+            CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: "cosmos2contract".to_string(),
+                msg: to_binary(&ExecuteMsg::Yourself {
+                    yourself_msg: YourselfMsg::TransferUst {
+                        receiver: "addr0000".to_string(),
+                    },
+                })
+                .unwrap(),
+                funds: vec![],
+            }),
+        ])
+        .add_attributes(vec![attr("action", "withdraw"), attr("position_idx", "1")]);
+    assert_eq!(res, expected_res)
+}
+

--- a/packages/andromeda_protocol/src/anchor.rs
+++ b/packages/andromeda_protocol/src/anchor.rs
@@ -1,3 +1,4 @@
+use crate::communication::{AndromedaMsg, AndromedaQuery};
 use cosmwasm_std::Uint128;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -6,9 +7,8 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "snake_case")]
 pub enum AnchorMarketMsg {
     DepositStable {},
-    RedeemStable{}
+    RedeemStable {},
 }
-
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
@@ -20,24 +20,23 @@ pub struct InstantiateMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
+    AndrReceive(AndromedaMsg),
     Deposit {},
-    Withdraw {  position_idx: Uint128 },
+    Withdraw { position_idx: Uint128 },
     Yourself { yourself_msg: YourselfMsg },
-    UpdateOwner {
-        address: String,
-    },
 }
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum YourselfMsg {
-    TransferUst{ receiver: String },
+    TransferUst { receiver: String },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
-    Config{},
-    ContractOwner {},
+    AndrQuery(AndromedaQuery),
+    Config {},
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -47,5 +46,3 @@ pub struct ConfigResponse {
     pub anchor_token: String,
     pub stable_denom: String,
 }
-
-

--- a/packages/andromeda_protocol/src/lib.rs
+++ b/packages/andromeda_protocol/src/lib.rs
@@ -1,6 +1,7 @@
 use crate::error::ContractError;
 
 pub mod address_list;
+pub mod anchor;
 pub mod common;
 pub mod communication;
 pub mod error;
@@ -14,7 +15,6 @@ pub mod rates;
 pub mod receipt;
 pub mod response;
 pub mod splitter;
-pub mod anchor;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod testing;


### PR DESCRIPTION
For `AndromedaMsg::Receive(data)` I decided to have the following behaviour:

If `data` is `None`, treat this as a deposit request (funds in `info.funds`). 

if `data` is `Some(binary)`, assume that binary is a `Uint128` which represents the position from which to withdraw funds. 

I think we could even remove the existing `ExecuteMsg::Withdraw and Deposit` so let me know your thoughts on that.