### PR TITLE
Anchor Contract: Changed Map to IndexedMap and added query to get all owned positions for an address

### DIFF
--- a/contracts/andromeda_anchor/src/state.rs
+++ b/contracts/andromeda_anchor/src/state.rs
@@ -1,12 +1,11 @@
+use andromeda_protocol::anchor::Position;
 use cosmwasm_std::{Addr, CanonicalAddr, Uint128};
-use cw_storage_plus::{Index, IndexList, IndexedMap, Item, Map, MultiIndex, U128Key};
+use cw_storage_plus::{Index, IndexList, IndexedMap, Item, MultiIndex, U128Key};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 pub const CONFIG: Item<Config> = Item::new("config");
 pub const KEY_POSITION_IDX: Item<Uint128> = Item::new("position_idx");
-pub const POSITION: Map<&[u8], Position> = Map::new("position");
-//pub const POSITION_IDXS: Map<&str, Vec<Uint128>> = Map::new("position_idxs");
 pub const PREV_AUST_BALANCE: Item<Uint128> = Item::new("prev_aust_balance");
 pub const TEMP_BALANCE: Item<Uint128> = Item::new("temp_balance");
 
@@ -15,14 +14,6 @@ pub struct Config {
     pub anchor_mint: CanonicalAddr,
     pub anchor_token: CanonicalAddr,
     pub stable_denom: String,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct Position {
-    pub idx: Uint128,
-    pub owner: Addr,
-    pub deposit_amount: Uint128,
-    pub aust_amount: Uint128,
 }
 
 pub struct PositionIndexes<'a> {

--- a/contracts/andromeda_anchor/src/state.rs
+++ b/contracts/andromeda_anchor/src/state.rs
@@ -1,17 +1,17 @@
-use cosmwasm_std::{CanonicalAddr, Uint128};
-use cw_storage_plus::{Item, Map};
+use cosmwasm_std::{Addr, CanonicalAddr, Uint128};
+use cw_storage_plus::{Index, IndexList, IndexedMap, Item, Map, MultiIndex, U128Key};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
 
 pub const CONFIG: Item<Config> = Item::new("config");
 pub const KEY_POSITION_IDX: Item<Uint128> = Item::new("position_idx");
 pub const POSITION: Map<&[u8], Position> = Map::new("position");
+//pub const POSITION_IDXS: Map<&str, Vec<Uint128>> = Map::new("position_idxs");
 pub const PREV_AUST_BALANCE: Item<Uint128> = Item::new("prev_aust_balance");
 pub const TEMP_BALANCE: Item<Uint128> = Item::new("temp_balance");
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct Config{
+pub struct Config {
     pub anchor_mint: CanonicalAddr,
     pub anchor_token: CanonicalAddr,
     pub stable_denom: String,
@@ -20,7 +20,30 @@ pub struct Config{
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Position {
     pub idx: Uint128,
-    pub owner: CanonicalAddr,
+    pub owner: Addr,
     pub deposit_amount: Uint128,
     pub aust_amount: Uint128,
 }
+
+pub struct PositionIndexes<'a> {
+    pub owner: MultiIndex<'a, (Addr, U128Key), Position>,
+}
+
+impl<'a> IndexList<Position> for PositionIndexes<'a> {
+    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<Position>> + '_> {
+        let v: Vec<&dyn Index<Position>> = vec![&self.owner];
+        Box::new(v.into_iter())
+    }
+}
+
+pub fn positions<'a>() -> IndexedMap<'a, U128Key, Position, PositionIndexes<'a>> {
+    let indexes = PositionIndexes {
+        owner: MultiIndex::new(
+            |p, k| (p.owner.clone(), k.into()),
+            "ownership",
+            "positions_owner",
+        ),
+    };
+    IndexedMap::new("ownership", indexes)
+}
+

--- a/contracts/andromeda_anchor/src/testing/tests.rs
+++ b/contracts/andromeda_anchor/src/testing/tests.rs
@@ -1,5 +1,5 @@
 use crate::contract::{execute, instantiate};
-use crate::state::{CONFIG, POSITION};
+use crate::state::{positions, CONFIG, POSITION};
 use crate::testing::mock_querier::mock_dependencies_custom;
 use andromeda_protocol::{
     anchor::{AnchorMarketMsg, ExecuteMsg, InstantiateMsg, YourselfMsg},
@@ -11,6 +11,7 @@ use cosmwasm_std::{
     to_binary, Api, Coin, CosmosMsg, Response, SubMsg, Uint128, WasmMsg,
 };
 use cw20::Cw20ExecuteMsg;
+use cw_storage_plus::U128Key;
 
 #[test]
 fn test_instantiate() {
@@ -106,10 +107,16 @@ fn test_withdraw() {
     let env = mock_env();
     let _res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
     //set aust_amount to position manually
-    let mut position = POSITION.load(&deps.storage, &1u128.to_be_bytes()).unwrap();
+    //let mut position = POSITION.load(&deps.storage, &1u128.to_be_bytes()).unwrap();
+    let mut position = positions()
+        .load(deps.as_mut().storage, U128Key::new(1u128))
+        .unwrap();
     position.aust_amount = Uint128::from(1000000u128);
-    POSITION
-        .save(deps.as_mut().storage, &1u128.to_be_bytes(), &position)
+    /*POSITION
+    .save(deps.as_mut().storage, &1u128.to_be_bytes(), &position)
+    .unwrap();*/
+    positions()
+        .save(deps.as_mut().storage, U128Key::new(1u128), &position)
         .unwrap();
 
     let msg = ExecuteMsg::Withdraw {
@@ -182,10 +189,15 @@ fn test_andr_receive() {
     assert_eq!(res, expected_res);
 
     //set aust_amount to position manually
-    let mut position = POSITION.load(&deps.storage, &1u128.to_be_bytes()).unwrap();
+    let mut position = positions()
+        .load(deps.as_mut().storage, U128Key::new(1u128))
+        .unwrap();
     position.aust_amount = Uint128::from(1000000u128);
-    POSITION
-        .save(deps.as_mut().storage, &1u128.to_be_bytes(), &position)
+    /*POSITION
+    .save(deps.as_mut().storage, &1u128.to_be_bytes(), &position)
+    .unwrap();*/
+    positions()
+        .save(deps.as_mut().storage, U128Key::new(1u128), &position)
         .unwrap();
 
     let msg = ExecuteMsg::AndrReceive(AndromedaMsg::Receive(Some(
@@ -221,4 +233,3 @@ fn test_andr_receive() {
         .add_attributes(vec![attr("action", "withdraw"), attr("position_idx", "1")]);
     assert_eq!(res, expected_res)
 }
-

--- a/packages/andromeda_protocol/src/anchor.rs
+++ b/packages/andromeda_protocol/src/anchor.rs
@@ -46,3 +46,9 @@ pub struct ConfigResponse {
     pub anchor_token: String,
     pub stable_denom: String,
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct PositionIdxsResponse {
+    pub idxs: Vec<Uint128>,
+}

--- a/packages/andromeda_protocol/src/anchor.rs
+++ b/packages/andromeda_protocol/src/anchor.rs
@@ -1,5 +1,5 @@
 use crate::communication::{AndromedaMsg, AndromedaQuery};
-use cosmwasm_std::Uint128;
+use cosmwasm_std::{Addr, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -37,6 +37,11 @@ pub enum YourselfMsg {
 pub enum QueryMsg {
     AndrQuery(AndromedaQuery),
     Config {},
+    Positions {
+        address: String,
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -48,7 +53,15 @@ pub struct ConfigResponse {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct Position {
+    pub idx: Uint128,
+    pub owner: Addr,
+    pub deposit_amount: Uint128,
+    pub aust_amount: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub struct PositionIdxsResponse {
-    pub idxs: Vec<Uint128>,
+pub struct PositionsResponse {
+    pub positions: Vec<Position>,
 }


### PR DESCRIPTION
Removed `POSITIONS` in favour of `IndexedMap` approach similar to `tokens()` for the Token contract. This was necessary to easily get the owned positions for a given address. 

I also changed the behaviour of `AndromedaQuery::Get(binary)` for anchor by assuming that `binary` is the address the sender wants the positions for. 