### PR TITLE
Added query that generates fee messages to the Rates contract

### DIFF
--- a/contracts/andromeda_anchor/src/contract.rs
+++ b/contracts/andromeda_anchor/src/contract.rs
@@ -212,9 +212,10 @@ pub fn transfer_ust(
     let transfer_amount = current_balance - prev_balance;
     let mut msgs = vec![];
     if transfer_amount > Uint128::zero() {
-        msgs.push(
-            receiver.generate_msg(&deps, coins(transfer_amount.u128(), config.stable_denom))?,
-        );
+        msgs.push(receiver.generate_msg(
+            &deps.as_ref(),
+            coins(transfer_amount.u128(), config.stable_denom),
+        )?);
     }
     Ok(Response::new().add_submessages(msgs).add_attributes(vec![
         attr("action", "withdraw"),

--- a/contracts/andromeda_rates/src/contract.rs
+++ b/contracts/andromeda_rates/src/contract.rs
@@ -1,13 +1,18 @@
 use crate::state::{Config, CONFIG};
 use andromeda_protocol::{
-    communication::{encode_binary, parse_message, AndromedaMsg, AndromedaQuery},
+    communication::{encode_binary, parse_message, parse_message, AndromedaMsg, AndromedaQuery},
     error::ContractError,
+    modules::common::{calculate_fee, deduct_funds},
     operators::{execute_update_operators, query_is_operator, query_operators},
     ownership::{execute_update_owner, is_contract_owner, query_contract_owner, CONTRACT_OWNER},
-    rates::{ExecuteMsg, InstantiateMsg, PaymentsResponse, QueryMsg, RateInfo},
+    rates::{
+        DeductedFundsResponse, ExecuteMsg, InstantiateMsg, PaymentsResponse, QueryMsg, RateInfo,
+    },
     require,
 };
-use cosmwasm_std::{attr, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Response};
+use cosmwasm_std::{
+    attr, entry_point, Binary, Coin, Deps, DepsMut, Env, MessageInfo, Response, SubMsg,
+};
 
 #[entry_point]
 pub fn instantiate(
@@ -78,7 +83,10 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
 
 fn handle_andromeda_query(deps: Deps, msg: AndromedaQuery) -> Result<Binary, ContractError> {
     match msg {
-        AndromedaQuery::Get(_) => encode_binary(&query_payments(deps)?),
+        AndromedaQuery::Get(data) => {
+            let coin: Coin = parse_message(data)?;
+            encode_binary(&query_deducted_funds(deps, coin)?)
+        }
         AndromedaQuery::Owner {} => encode_binary(&query_contract_owner(deps)?),
         AndromedaQuery::Operators {} => encode_binary(&query_operators(deps)?),
         AndromedaQuery::IsOperator { address } => {
@@ -94,17 +102,33 @@ fn query_payments(deps: Deps) -> Result<PaymentsResponse, ContractError> {
     Ok(PaymentsResponse { payments: rates })
 }
 
+fn query_deducted_funds(deps: Deps, coin: Coin) -> Result<DeductedFundsResponse, ContractError> {
+    let config = CONFIG.load(deps.storage)?;
+    let mut deducted_funds = vec![coin];
+    let mut msgs: Vec<SubMsg> = vec![];
+    for rate_info in config.rates.iter() {
+        // TODO: Figure out what rate_info.is_additive does.
+        let rate = rate_info.rate.validate(&deps.querier)?;
+        let fee = calculate_fee(rate, &deducted_funds[0])?;
+        deduct_funds(&mut deducted_funds, &fee)?;
+        for reciever in rate_info.receivers.iter() {
+            msgs.push(reciever.generate_msg(&deps, vec![fee.clone()])?);
+        }
+    }
+    Ok(DeductedFundsResponse { msgs })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::contract::{execute, instantiate, query};
     use andromeda_protocol::{
-        communication::{encode_binary, AndromedaMsg, AndromedaQuery},
+        communication::{encode_binary, AndromedaMsg, AndromedaQuery, Recipient},
         modules::Rate,
         rates::{InstantiateMsg, PaymentsResponse, QueryMsg, RateInfo},
     };
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-    use cosmwasm_std::{Addr, Coin, Uint128};
+    use cosmwasm_std::{Coin, Uint128};
 
     #[test]
     fn test_instantiate_query() {
@@ -117,7 +141,7 @@ mod tests {
                 rate: Rate::Percent(10u128.into()),
                 is_additive: true,
                 description: Some("desc1".to_string()),
-                receivers: vec![Addr::unchecked("")],
+                receivers: vec![Recipient::Addr("".into())],
             },
             RateInfo {
                 rate: Rate::Flat(Coin {
@@ -126,7 +150,7 @@ mod tests {
                 }),
                 is_additive: false,
                 description: Some("desc2".to_string()),
-                receivers: vec![Addr::unchecked("")],
+                receivers: vec![Recipient::Addr("".into())],
             },
         ];
         let msg = InstantiateMsg {
@@ -159,7 +183,7 @@ mod tests {
                 rate: Rate::Percent(10u128.into()),
                 is_additive: true,
                 description: Some("desc1".to_string()),
-                receivers: vec![Addr::unchecked("")],
+                receivers: vec![Recipient::Addr("".into())],
             },
             RateInfo {
                 rate: Rate::Flat(Coin {
@@ -168,7 +192,7 @@ mod tests {
                 }),
                 is_additive: false,
                 description: Some("desc2".to_string()),
-                receivers: vec![Addr::unchecked("")],
+                receivers: vec![Recipient::Addr("".into())],
             },
         ];
         let msg = InstantiateMsg { rates: vec![] };

--- a/contracts/andromeda_rates/src/contract.rs
+++ b/contracts/andromeda_rates/src/contract.rs
@@ -1,6 +1,6 @@
 use crate::state::{Config, CONFIG};
 use andromeda_protocol::{
-    communication::{encode_binary, parse_message, parse_message, AndromedaMsg, AndromedaQuery},
+    communication::{encode_binary, parse_message, AndromedaMsg, AndromedaQuery},
     error::ContractError,
     modules::common::{calculate_fee, deduct_funds},
     operators::{execute_update_operators, query_is_operator, query_operators},
@@ -124,11 +124,12 @@ mod tests {
     use crate::contract::{execute, instantiate, query};
     use andromeda_protocol::{
         communication::{encode_binary, AndromedaMsg, AndromedaQuery, Recipient},
-        modules::Rate,
+        modules::{ADORate, Rate},
         rates::{InstantiateMsg, PaymentsResponse, QueryMsg, RateInfo},
+        testing::mock_querier::{mock_dependencies_custom, MOCK_PRIMITIVE_CONTRACT},
     };
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-    use cosmwasm_std::{Coin, Uint128};
+    use cosmwasm_std::{coin, coins, from_binary, BankMsg, Coin, CosmosMsg, Uint128};
 
     #[test]
     fn test_instantiate_query() {
@@ -206,14 +207,71 @@ mod tests {
             Response::new().add_attributes(vec![attr("action", "update_rates")]),
             res
         );
+    }
 
-        let msg = QueryMsg::AndrQuery(AndromedaQuery::Get(None));
+    #[test]
+    fn test_query_deducted_funds() {
+        let mut deps = mock_dependencies_custom(&[]);
+        let env = mock_env();
+        let owner = "owner";
+        let info = mock_info(owner, &[]);
+        let rates = vec![
+            RateInfo {
+                rate: Rate::Percent(10u128.into()),
+                is_additive: true,
+                description: Some("desc1".to_string()),
+                receivers: vec![Recipient::Addr("1".into())],
+            },
+            RateInfo {
+                rate: Rate::Flat(Coin {
+                    amount: Uint128::from(20u128),
+                    denom: "uusd".to_string(),
+                }),
+                is_additive: false,
+                description: Some("desc2".to_string()),
+                receivers: vec![Recipient::Addr("2".into())],
+            },
+            RateInfo {
+                rate: Rate::External(ADORate {
+                    address: MOCK_PRIMITIVE_CONTRACT.into(),
+                    key: Some("flat".into()),
+                }),
+                is_additive: false,
+                description: Some("desc3".to_string()),
+                receivers: vec![Recipient::Addr("3".into())],
+            },
+        ];
+        let msg = InstantiateMsg {
+            rates: rates.clone(),
+        };
+        let _res = instantiate(deps.as_mut(), env.clone(), info, msg).unwrap();
 
-        let payments = query(deps.as_ref(), env, msg).unwrap();
+        let res: DeductedFundsResponse = from_binary(
+            &query(
+                deps.as_ref(),
+                env,
+                QueryMsg::AndrQuery(AndromedaQuery::Get(Some(
+                    encode_binary(&coin(100, "uusd")).unwrap(),
+                ))),
+            )
+            .unwrap(),
+        )
+        .unwrap();
 
-        assert_eq!(
-            payments,
-            encode_binary(&PaymentsResponse { payments: rates }).unwrap()
-        );
+        let expected_msgs: Vec<SubMsg> = vec![
+            SubMsg::new(CosmosMsg::Bank(BankMsg::Send {
+                to_address: "1".into(),
+                amount: coins(10, "uusd"),
+            })),
+            SubMsg::new(CosmosMsg::Bank(BankMsg::Send {
+                to_address: "2".into(),
+                amount: coins(20, "uusd"),
+            })),
+            SubMsg::new(CosmosMsg::Bank(BankMsg::Send {
+                to_address: "3".into(),
+                amount: coins(1, "uusd"),
+            })),
+        ];
+        assert_eq!(expected_msgs, res.msgs);
     }
 }

--- a/contracts/andromeda_splitter/src/contract.rs
+++ b/contracts/andromeda_splitter/src/contract.rs
@@ -140,7 +140,9 @@ fn execute_send(deps: DepsMut, info: MessageInfo) -> Result<Response, ContractEr
         }
         // ADO receivers must use AndromedaMsg::Receive to execute their functionality
         // Others may just receive the funds
-        let msg = recipient_addr.recipient.generate_msg(&deps, vec_coin)?;
+        let msg = recipient_addr
+            .recipient
+            .generate_msg(&deps.as_ref(), vec_coin)?;
         submsg.push(msg);
     }
     remainder_funds = remainder_funds

--- a/packages/andromeda_protocol/src/communication/mod.rs
+++ b/packages/andromeda_protocol/src/communication/mod.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    from_binary, to_binary, BankMsg, Binary, Coin, CosmosMsg, DepsMut, SubMsg, WasmMsg,
+    from_binary, to_binary, BankMsg, Binary, Coin, CosmosMsg, Deps, SubMsg, WasmMsg,
 };
 use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -42,7 +42,7 @@ impl Recipient {
     }
 
     /// Generates the sub message depending on the type of the recipient.
-    pub fn generate_msg(&self, deps: &DepsMut, funds: Vec<Coin>) -> Result<SubMsg, ContractError> {
+    pub fn generate_msg(&self, deps: &Deps, funds: Vec<Coin>) -> Result<SubMsg, ContractError> {
         Ok(match &self {
             Recipient::ADO(recip) => SubMsg::new(WasmMsg::Execute {
                 contract_addr: deps.api.addr_validate(&recip.addr)?.to_string(),

--- a/packages/andromeda_protocol/src/modules/royalties.rs
+++ b/packages/andromeda_protocol/src/modules/royalties.rs
@@ -34,7 +34,7 @@ impl MessageHooks for Royalty {
         agreement: TransferAgreement,
     ) -> Result<HookResponse, ContractError> {
         let rate = self.rate.validate(&deps.querier)?;
-        let fee_payment = calculate_fee(rate, agreement.amount)?;
+        let fee_payment = calculate_fee(rate, &agreement.amount)?;
         let mut resp = HookResponse::default();
         let mut event = Event::new("royalty");
 
@@ -207,7 +207,7 @@ mod tests {
         assert_eq!(resp.events[0].attributes[1].key, ATTR_DEDUCTED);
         assert_eq!(
             resp.events[0].attributes[1].value,
-            calculate_fee(royalty.rate.clone(), agreed_amount.clone())
+            calculate_fee(royalty.rate.clone(), &agreed_amount)
                 .unwrap()
                 .to_string()
         );
@@ -216,7 +216,7 @@ mod tests {
             resp.events[0].attributes[2].value,
             PaymentAttribute {
                 receiver: royalty.receivers[0].clone(),
-                amount: calculate_fee(royalty.rate.clone(), agreed_amount).unwrap()
+                amount: calculate_fee(royalty.rate.clone(), &agreed_amount).unwrap()
             }
             .to_string()
         );

--- a/packages/andromeda_protocol/src/modules/taxable.rs
+++ b/packages/andromeda_protocol/src/modules/taxable.rs
@@ -40,7 +40,7 @@ impl MessageHooks for Taxable {
     ) -> Result<HookResponse, ContractError> {
         let _contract_addr = env.contract.address;
         let rate = self.rate.validate(&deps.querier)?;
-        let tax_amount = calculate_fee(rate, agreement.amount)?;
+        let tax_amount = calculate_fee(rate, &agreement.amount)?;
 
         let mut resp = HookResponse::default();
         let mut event = Event::new(TAX_EVENT_ID);
@@ -239,7 +239,7 @@ mod tests {
             resp.events[0].attributes[1].value,
             PaymentAttribute {
                 receiver: t.receivers[0].clone(),
-                amount: calculate_fee(t.rate, agreed_transfer_amount).unwrap()
+                amount: calculate_fee(t.rate, &agreed_transfer_amount).unwrap()
             }
             .to_string()
         );

--- a/packages/andromeda_protocol/src/rates.rs
+++ b/packages/andromeda_protocol/src/rates.rs
@@ -1,8 +1,8 @@
 use crate::{
-    communication::{AndromedaMsg, AndromedaQuery},
+    communication::{AndromedaMsg, AndromedaQuery, Recipient},
     modules::Rate,
 };
-use cosmwasm_std::Addr;
+use cosmwasm_std::SubMsg;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -31,9 +31,14 @@ pub struct PaymentsResponse {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct DeductedFundsResponse {
+    pub msgs: Vec<SubMsg>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct RateInfo {
     pub rate: Rate,
     pub is_additive: bool,
     pub description: Option<String>,
-    pub receivers: Vec<Addr>,
+    pub receivers: Vec<Recipient>,
 }

--- a/packages/andromeda_protocol/src/token.rs
+++ b/packages/andromeda_protocol/src/token.rs
@@ -141,7 +141,7 @@ impl TransferAgreement {
     ) -> Result<BankMsg, ContractError> {
         Ok(BankMsg::Send {
             to_address,
-            amount: vec![calculate_fee(rate, self.amount.clone())?],
+            amount: vec![calculate_fee(rate, &self.amount)?],
         })
     }
     /// Generates an event related to the agreed transfer of a token


### PR DESCRIPTION
- Changed `RatesInfo.receivers` from `Vec<Addr>` to `Vec<Recipient>` for more functionality
- Added a query method `query_deducted_funds(Deps, Coin)` to Rates Contract which returns a response containing the payment messages for each rate. This query is now hooked up to `AndromedaQuery::Get(binary)` where `binary` is assumed to be the `Coin` to generate rate payments from.
- Changed signature of `calculate_fee(..., Coin)` to `calculate_fee(..., &Coin)` to limit number of clones
- Changed signature of `Recipient.generate_msg(&DepsMut,...)` to `Recipient.generate_msg(&Deps,...)` to be able to use it in queries