### PR TITLE
Changed anchor AndromedaMsg::Receive behaviour to be more general

### DIFF
--- a/contracts/andromeda_anchor/src/contract.rs
+++ b/contracts/andromeda_anchor/src/contract.rs
@@ -69,13 +69,13 @@ fn execute_andr_receive(
     msg: AndromedaMsg,
 ) -> Result<Response, ContractError> {
     match msg {
-        AndromedaMsg::Receive(data) => match data {
-            None => execute_deposit(deps, env, info, None),
-            Some(_) => {
-                let position_idx: Uint128 = parse_message(data)?;
-                withdraw(deps, env, info, position_idx)
+        AndromedaMsg::Receive(data) => {
+            let received: ExecuteMsg = parse_message(data)?;
+            match received {
+                ExecuteMsg::AndrReceive(..) => Err(ContractError::NestedAndromedaMsg {}),
+                _ => execute(deps, env, info, received),
             }
-        },
+        }
         AndromedaMsg::UpdateOwner { address } => execute_update_owner(deps, info, address),
         AndromedaMsg::UpdateOperators { operators } => {
             execute_update_operators(deps, info, operators)

--- a/contracts/andromeda_anchor/src/testing/tests.rs
+++ b/contracts/andromeda_anchor/src/testing/tests.rs
@@ -219,7 +219,12 @@ fn test_andr_receive() {
     let info = mock_info("addr0000", &[]);
     let _res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
-    let msg = ExecuteMsg::AndrReceive(AndromedaMsg::Receive(None));
+    let msg = ExecuteMsg::AndrReceive(AndromedaMsg::Receive(Some(
+        to_binary(&ExecuteMsg::Deposit {
+            recipient: Some(Recipient::Addr("recipient".into())),
+        })
+        .unwrap(),
+    )));
     let info = mock_info(
         "addr0000",
         &[Coin {
@@ -252,7 +257,10 @@ fn test_andr_receive() {
         .unwrap();
 
     let msg = ExecuteMsg::AndrReceive(AndromedaMsg::Receive(Some(
-        to_binary(&Uint128::from(1u128)).unwrap(),
+        to_binary(&ExecuteMsg::Withdraw {
+            position_idx: 1u128.into(),
+        })
+        .unwrap(),
     )));
 
     let info = mock_info("addr0000", &[]);
@@ -274,7 +282,7 @@ fn test_andr_receive() {
                 contract_addr: "cosmos2contract".to_string(),
                 msg: to_binary(&ExecuteMsg::Yourself {
                     yourself_msg: YourselfMsg::TransferUst {
-                        receiver: Recipient::Addr("addr0000".to_string()),
+                        receiver: Recipient::Addr("recipient".to_string()),
                     },
                 })
                 .unwrap(),

--- a/packages/andromeda_protocol/src/communication/mod.rs
+++ b/packages/andromeda_protocol/src/communication/mod.rs
@@ -16,7 +16,6 @@ pub struct ADORecipient {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
 pub enum Recipient {
     Addr(String),
     ADO(ADORecipient),


### PR DESCRIPTION
I replaced the specific `AndromedaMsg::Receive` implementation with the general one as it did not allow depositing with a specific recipient. I also removed `#[serde(rename_all = "snake_case")]` from `Recipient` as it made it so specifying an ADO recipient required the user to write `a_d_o: ...` which seemed unnecessary. 