### PR TITLE
CU-1vkx5xq | Added support for Cw20 rate deductions to Rates Contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,7 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-storage-plus 0.9.1",
+ "cw20 0.9.1",
  "schemars",
  "serde",
 ]

--- a/contracts/andromeda_anchor/src/contract.rs
+++ b/contracts/andromeda_anchor/src/contract.rs
@@ -212,7 +212,7 @@ pub fn transfer_ust(
     let transfer_amount = current_balance - prev_balance;
     let mut msgs = vec![];
     if transfer_amount > Uint128::zero() {
-        msgs.push(receiver.generate_msg(
+        msgs.push(receiver.generate_msg_native(
             &deps.as_ref(),
             coins(transfer_amount.u128(), config.stable_denom),
         )?);

--- a/contracts/andromeda_anchor/src/testing/tests.rs
+++ b/contracts/andromeda_anchor/src/testing/tests.rs
@@ -178,7 +178,7 @@ fn test_withdraw_recipient() {
     let msg = ExecuteMsg::Withdraw {
         position_idx: Uint128::from(1u128),
     };
-    let res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+    let res = execute(deps.as_mut(), env, info, msg).unwrap();
 
     let expected_res = Response::new()
         .add_messages(vec![
@@ -196,7 +196,7 @@ fn test_withdraw_recipient() {
                 contract_addr: "cosmos2contract".to_string(),
                 msg: to_binary(&ExecuteMsg::Yourself {
                     yourself_msg: YourselfMsg::TransferUst {
-                        receiver: Recipient::Addr(recipient.to_string()),
+                        receiver: Recipient::Addr(recipient),
                     },
                 })
                 .unwrap(),

--- a/contracts/andromeda_rates/Cargo.toml
+++ b/contracts/andromeda_rates/Cargo.toml
@@ -25,4 +25,5 @@ serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 schemars = "0.8.3"
 cosmwasm-storage = "0.16.0"
 cw-storage-plus = "0.9.1"
+cw20 = "0.9.1"
 andromeda-protocol = { version = "0.1.0", path = "../../packages/andromeda_protocol" }

--- a/contracts/andromeda_rates/src/contract.rs
+++ b/contracts/andromeda_rates/src/contract.rs
@@ -2,17 +2,19 @@ use crate::state::{Config, CONFIG};
 use andromeda_protocol::{
     communication::{encode_binary, parse_message, AndromedaMsg, AndromedaQuery},
     error::ContractError,
-    modules::common::calculate_fee,
+    modules::common::{calculate_fee, deduct_funds},
     operators::{execute_update_operators, query_is_operator, query_operators},
     ownership::{execute_update_owner, is_contract_owner, query_contract_owner, CONTRACT_OWNER},
     rates::{
-        DeductedFundsResponse, ExecuteMsg, InstantiateMsg, PaymentsResponse, QueryMsg, RateInfo,
+        DeductedFundsResponse, ExecuteMsg, Funds, InstantiateMsg, PaymentsResponse, QueryMsg,
+        RateInfo,
     },
     require,
 };
 use cosmwasm_std::{
-    attr, entry_point, Binary, Coin, Deps, DepsMut, Env, MessageInfo, Response, SubMsg,
+    attr, coin, entry_point, Binary, Coin, Deps, DepsMut, Env, MessageInfo, Response, SubMsg,
 };
+use cw20::Cw20Coin;
 
 #[entry_point]
 pub fn instantiate(
@@ -84,8 +86,8 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
 fn handle_andromeda_query(deps: Deps, msg: AndromedaQuery) -> Result<Binary, ContractError> {
     match msg {
         AndromedaQuery::Get(data) => {
-            let coin: Coin = parse_message(data)?;
-            encode_binary(&query_deducted_funds(deps, coin)?)
+            let funds: Funds = parse_message(data)?;
+            encode_binary(&query_deducted_funds(deps, funds)?)
         }
         AndromedaQuery::Owner {} => encode_binary(&query_contract_owner(deps)?),
         AndromedaQuery::Operators {} => encode_binary(&query_operators(deps)?),
@@ -102,17 +104,46 @@ fn query_payments(deps: Deps) -> Result<PaymentsResponse, ContractError> {
     Ok(PaymentsResponse { payments: rates })
 }
 
-fn query_deducted_funds(deps: Deps, coin: Coin) -> Result<DeductedFundsResponse, ContractError> {
+fn query_deducted_funds(deps: Deps, funds: Funds) -> Result<DeductedFundsResponse, ContractError> {
     let config = CONFIG.load(deps.storage)?;
     let mut msgs: Vec<SubMsg> = vec![];
+    let (coin, is_native): (Coin, bool) = match funds {
+        Funds::Native(coin) => (coin, true),
+        Funds::Cw20(cw20_coin) => (coin(cw20_coin.amount.u128(), cw20_coin.address), false),
+    };
+    let mut leftover_funds = vec![coin.clone()];
     for rate_info in config.rates.iter() {
         let rate = rate_info.rate.validate(&deps.querier)?;
         let fee = calculate_fee(rate, &coin)?;
         for reciever in rate_info.receivers.iter() {
-            msgs.push(reciever.generate_msg(&deps, vec![fee.clone()])?);
+            if !rate_info.is_additive {
+                deduct_funds(&mut leftover_funds, &fee)?;
+            }
+            let msg = if is_native {
+                reciever.generate_msg_native(&deps, vec![fee.clone()])?
+            } else {
+                reciever.generate_msg_cw20(
+                    &deps,
+                    Cw20Coin {
+                        amount: fee.amount,
+                        address: fee.denom.to_string(),
+                    },
+                )?
+            };
+            msgs.push(msg);
         }
     }
-    Ok(DeductedFundsResponse { msgs })
+    Ok(DeductedFundsResponse {
+        msgs,
+        leftover_funds: if is_native {
+            Funds::Native(leftover_funds[0].clone())
+        } else {
+            Funds::Cw20(Cw20Coin {
+                amount: leftover_funds[0].amount,
+                address: coin.denom,
+            })
+        },
+    })
 }
 
 #[cfg(test)]
@@ -126,7 +157,8 @@ mod tests {
         testing::mock_querier::{mock_dependencies_custom, MOCK_PRIMITIVE_CONTRACT},
     };
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-    use cosmwasm_std::{coin, coins, from_binary, BankMsg, Coin, CosmosMsg, Uint128};
+    use cosmwasm_std::{coin, coins, from_binary, BankMsg, Coin, CosmosMsg, Uint128, WasmMsg};
+    use cw20::Cw20ExecuteMsg;
 
     #[test]
     fn test_instantiate_query() {
@@ -207,7 +239,7 @@ mod tests {
     }
 
     #[test]
-    fn test_query_deducted_funds() {
+    fn test_query_deducted_funds_native() {
         let mut deps = mock_dependencies_custom(&[]);
         let env = mock_env();
         let owner = "owner";
@@ -218,13 +250,13 @@ mod tests {
                     amount: Uint128::from(20u128),
                     denom: "uusd".to_string(),
                 }),
-                is_additive: false,
+                is_additive: true,
                 description: Some("desc2".to_string()),
                 receivers: vec![Recipient::Addr("1".into())],
             },
             RateInfo {
                 rate: Rate::Percent(10u128.into()),
-                is_additive: true,
+                is_additive: false,
                 description: Some("desc1".to_string()),
                 receivers: vec![Recipient::Addr("2".into())],
             },
@@ -248,7 +280,7 @@ mod tests {
                 deps.as_ref(),
                 env,
                 QueryMsg::AndrQuery(AndromedaQuery::Get(Some(
-                    encode_binary(&coin(100, "uusd")).unwrap(),
+                    encode_binary(&Funds::Native(coin(100, "uusd"))).unwrap(),
                 ))),
             )
             .unwrap(),
@@ -269,6 +301,109 @@ mod tests {
                 amount: coins(1, "uusd"),
             })),
         ];
-        assert_eq!(expected_msgs, res.msgs);
+        assert_eq!(
+            DeductedFundsResponse {
+                msgs: expected_msgs,
+                // Deduct 10% from the percent rate, followed by flat fee of 1 from the external rate.
+                leftover_funds: Funds::Native(coin(89, "uusd"))
+            },
+            res
+        );
+    }
+
+    #[test]
+    fn test_query_deducted_funds_cw20() {
+        let mut deps = mock_dependencies_custom(&[]);
+        let env = mock_env();
+        let owner = "owner";
+        let info = mock_info(owner, &[]);
+        let cw20_address = "address";
+        let rates = vec![
+            RateInfo {
+                rate: Rate::Flat(Coin {
+                    amount: Uint128::from(20u128),
+                    denom: cw20_address.to_string(),
+                }),
+                is_additive: true,
+                description: Some("desc2".to_string()),
+                receivers: vec![Recipient::Addr("1".into())],
+            },
+            RateInfo {
+                rate: Rate::Percent(10u128.into()),
+                is_additive: false,
+                description: Some("desc1".to_string()),
+                receivers: vec![Recipient::Addr("2".into())],
+            },
+            RateInfo {
+                rate: Rate::External(ADORate {
+                    address: MOCK_PRIMITIVE_CONTRACT.into(),
+                    key: Some("flat_cw20".into()),
+                }),
+                is_additive: false,
+                description: Some("desc3".to_string()),
+                receivers: vec![Recipient::Addr("3".into())],
+            },
+        ];
+        let msg = InstantiateMsg {
+            rates: rates.clone(),
+        };
+        let _res = instantiate(deps.as_mut(), env.clone(), info, msg).unwrap();
+
+        let res: DeductedFundsResponse = from_binary(
+            &query(
+                deps.as_ref(),
+                env,
+                QueryMsg::AndrQuery(AndromedaQuery::Get(Some(
+                    encode_binary(&Funds::Cw20(Cw20Coin {
+                        amount: 100u128.into(),
+                        address: "address".into(),
+                    }))
+                    .unwrap(),
+                ))),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+        let expected_msgs: Vec<SubMsg> = vec![
+            SubMsg::new(WasmMsg::Execute {
+                contract_addr: cw20_address.to_string(),
+                msg: encode_binary(&Cw20ExecuteMsg::Transfer {
+                    recipient: "1".to_string(),
+                    amount: 20u128.into(),
+                })
+                .unwrap(),
+                funds: vec![],
+            }),
+            SubMsg::new(WasmMsg::Execute {
+                contract_addr: cw20_address.to_string(),
+                msg: encode_binary(&Cw20ExecuteMsg::Transfer {
+                    recipient: "2".to_string(),
+                    amount: 10u128.into(),
+                })
+                .unwrap(),
+                funds: vec![],
+            }),
+            SubMsg::new(WasmMsg::Execute {
+                contract_addr: cw20_address.to_string(),
+                msg: encode_binary(&Cw20ExecuteMsg::Transfer {
+                    recipient: "3".to_string(),
+                    amount: 1u128.into(),
+                })
+                .unwrap(),
+                funds: vec![],
+            }),
+        ];
+        assert_eq!(
+            DeductedFundsResponse {
+                msgs: expected_msgs,
+                // Deduct 10% from the percent rate, followed by flat fee of 1 from the external rate.
+                leftover_funds: Funds::Cw20(Cw20Coin {
+                    amount: 89u128.into(),
+                    address: cw20_address.to_string()
+                })
+            },
+            res
+        );
     }
 }

--- a/contracts/andromeda_rates/src/contract.rs
+++ b/contracts/andromeda_rates/src/contract.rs
@@ -231,7 +231,7 @@ mod tests {
         let msg =
             ExecuteMsg::AndrReceive(AndromedaMsg::Receive(Some(encode_binary(&rates).unwrap())));
 
-        let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+        let res = execute(deps.as_mut(), env, info, msg).unwrap();
         assert_eq!(
             Response::new().add_attributes(vec![attr("action", "update_rates")]),
             res
@@ -270,9 +270,7 @@ mod tests {
                 receivers: vec![Recipient::Addr("3".into())],
             },
         ];
-        let msg = InstantiateMsg {
-            rates: rates.clone(),
-        };
+        let msg = InstantiateMsg { rates };
         let _res = instantiate(deps.as_mut(), env.clone(), info, msg).unwrap();
 
         let res: DeductedFundsResponse = from_binary(
@@ -344,9 +342,7 @@ mod tests {
                 receivers: vec![Recipient::Addr("3".into())],
             },
         ];
-        let msg = InstantiateMsg {
-            rates: rates.clone(),
-        };
+        let msg = InstantiateMsg { rates };
         let _res = instantiate(deps.as_mut(), env.clone(), info, msg).unwrap();
 
         let res: DeductedFundsResponse = from_binary(

--- a/contracts/andromeda_splitter/src/contract.rs
+++ b/contracts/andromeda_splitter/src/contract.rs
@@ -142,7 +142,7 @@ fn execute_send(deps: DepsMut, info: MessageInfo) -> Result<Response, ContractEr
         // Others may just receive the funds
         let msg = recipient_addr
             .recipient
-            .generate_msg(&deps.as_ref(), vec_coin)?;
+            .generate_msg_native(&deps.as_ref(), vec_coin)?;
         submsg.push(msg);
     }
     remainder_funds = remainder_funds

--- a/contracts/andromeda_timelock/src/contract.rs
+++ b/contracts/andromeda_timelock/src/contract.rs
@@ -174,7 +174,9 @@ fn execute_release_funds(
     for key in keys.iter() {
         let funds: Escrow = escrows().load(deps.storage, key.clone())?;
         if !funds.is_locked(&env.block)? {
-            let msg = funds.recipient.generate_msg(&deps.as_ref(), funds.coins)?;
+            let msg = funds
+                .recipient
+                .generate_msg_native(&deps.as_ref(), funds.coins)?;
             msgs.push(msg);
             escrows().remove(deps.storage, key.clone())?;
         }
@@ -208,7 +210,7 @@ fn execute_release_specific_funds(
             escrows().remove(deps.storage, key)?;
             let msg = escrow
                 .recipient
-                .generate_msg(&deps.as_ref(), escrow.coins)?;
+                .generate_msg_native(&deps.as_ref(), escrow.coins)?;
             Ok(Response::new().add_submessage(msg).add_attributes(vec![
                 attr("action", "release_funds"),
                 attr("recipient_addr", recipient),

--- a/contracts/andromeda_timelock/src/contract.rs
+++ b/contracts/andromeda_timelock/src/contract.rs
@@ -393,7 +393,7 @@ mod tests {
         let val: GetLockedFundsResponse = from_binary(&res).unwrap();
         let expected = Escrow {
             coins: funds,
-            condition: Some(condition.clone()),
+            condition: Some(condition),
             recipient: Recipient::Addr(owner.to_string()),
         };
 
@@ -416,7 +416,7 @@ mod tests {
 
         env.block.height = 0;
 
-        let _res = execute(deps.as_mut(), env.clone(), info.clone(), msg.clone()).unwrap();
+        let _res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
 
         let msg = ExecuteMsg::HoldFunds {
             condition: Some(EscrowCondition::Expiration(Expiration::AtHeight(100))),
@@ -426,7 +426,7 @@ mod tests {
         env.block.height = 120;
 
         let info = mock_info(owner, &[coin(100, "uusd"), coin(100, "uluna")]);
-        let _res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        let _res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
 
         let query_msg = QueryMsg::GetLockedFunds {
             owner: owner.to_string(),
@@ -467,7 +467,7 @@ mod tests {
             start_after: None,
             limit: None,
         };
-        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        let res = execute(deps.as_mut(), env, info.clone(), msg).unwrap();
         let bank_msg = BankMsg::Send {
             to_address: "owner".into(),
             amount: info.funds,
@@ -500,7 +500,7 @@ mod tests {
             start_after: None,
             limit: None,
         };
-        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        let res = execute(deps.as_mut(), env, info.clone(), msg).unwrap();
         let bank_msg = BankMsg::Send {
             to_address: "owner".into(),
             amount: info.funds,
@@ -526,10 +526,10 @@ mod tests {
             recipient: Some(recipient),
         };
         let info = mock_info("sender1", &coins(100, "uusd"));
-        let _res = execute(deps.as_mut(), env.clone(), info.clone(), msg.clone()).unwrap();
+        let _res = execute(deps.as_mut(), env.clone(), info, msg.clone()).unwrap();
 
         let info = mock_info("sender2", &coins(200, "uusd"));
-        let _res = execute(deps.as_mut(), env.clone(), info.clone(), msg.clone()).unwrap();
+        let _res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
 
         let msg = ExecuteMsg::ReleaseFunds {
             recipient_addr: Some("recipient".into()),
@@ -537,7 +537,7 @@ mod tests {
             limit: None,
         };
 
-        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        let res = execute(deps.as_mut(), env, info, msg).unwrap();
 
         let bank_msg1 = BankMsg::Send {
             to_address: "recipient".into(),
@@ -582,7 +582,7 @@ mod tests {
         };
 
         env.block.time = Timestamp::from_seconds(150);
-        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        let res = execute(deps.as_mut(), env, info.clone(), msg).unwrap();
         let bank_msg = BankMsg::Send {
             to_address: "owner".into(),
             amount: info.funds,
@@ -619,7 +619,7 @@ mod tests {
             limit: None,
         };
 
-        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg);
+        let res = execute(deps.as_mut(), env, info, msg);
         assert_eq!(ContractError::FundsAreLocked {}, res.unwrap_err());
     }
 
@@ -646,7 +646,7 @@ mod tests {
             limit: None,
         };
 
-        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg);
+        let res = execute(deps.as_mut(), env.clone(), info, msg);
         assert_eq!(ContractError::FundsAreLocked {}, res.unwrap_err());
 
         // Update the escrow with enough funds.
@@ -664,7 +664,7 @@ mod tests {
             limit: None,
         };
 
-        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg.clone()).unwrap();
+        let res = execute(deps.as_mut(), env, info, msg).unwrap();
 
         let bank_msg = BankMsg::Send {
             to_address: "owner".into(),
@@ -691,7 +691,7 @@ mod tests {
             recipient_addr: None,
             owner: owner.into(),
         };
-        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg);
+        let res = execute(deps.as_mut(), env, info, msg);
         assert_eq!(ContractError::NoLockedFunds {}, res.unwrap_err());
     }
 
@@ -713,7 +713,7 @@ mod tests {
             recipient_addr: None,
             owner: owner.into(),
         };
-        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        let res = execute(deps.as_mut(), env, info.clone(), msg).unwrap();
         let bank_msg = BankMsg::Send {
             to_address: "owner".into(),
             amount: info.funds,
@@ -750,7 +750,7 @@ mod tests {
         };
 
         env.block.time = Timestamp::from_seconds(150);
-        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        let res = execute(deps.as_mut(), env, info.clone(), msg).unwrap();
         let bank_msg = BankMsg::Send {
             to_address: "owner".into(),
             amount: info.funds,
@@ -786,7 +786,7 @@ mod tests {
             owner: owner.into(),
         };
 
-        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg);
+        let res = execute(deps.as_mut(), env.clone(), info, msg);
         assert_eq!(ContractError::FundsAreLocked {}, res.unwrap_err());
 
         // Update the escrow with enough funds.
@@ -803,7 +803,7 @@ mod tests {
             owner: owner.into(),
         };
 
-        let res = execute(deps.as_mut(), env.clone(), info.clone(), msg.clone()).unwrap();
+        let res = execute(deps.as_mut(), env, info, msg).unwrap();
 
         let bank_msg = BankMsg::Send {
             to_address: "owner".into(),

--- a/packages/andromeda_protocol/src/communication/mod.rs
+++ b/packages/andromeda_protocol/src/communication/mod.rs
@@ -70,9 +70,9 @@ impl Recipient {
     ) -> Result<SubMsg, ContractError> {
         Ok(match &self {
             Recipient::ADO(recip) => SubMsg::new(WasmMsg::Execute {
-                contract_addr: deps.api.addr_validate(&recip.addr)?.to_string(),
+                contract_addr: cw20_coin.address,
                 msg: encode_binary(&Cw20ExecuteMsg::Send {
-                    contract: cw20_coin.address,
+                    contract: deps.api.addr_validate(&recip.addr)?.to_string(),
                     amount: cw20_coin.amount,
                     msg: encode_binary(&ExecuteMsg::AndrReceive(AndromedaMsg::Receive(
                         recip.msg.clone(),
@@ -147,7 +147,8 @@ where
 
 #[cfg(test)]
 mod test {
-    use cosmwasm_std::to_binary;
+    use cosmwasm_std::testing::mock_dependencies;
+    use cosmwasm_std::{coins, to_binary};
     use cw721::Expiration;
 
     use super::*;
@@ -172,5 +173,89 @@ mod test {
         let invalid_json = to_binary("notavalidteststruct").unwrap();
 
         assert!(parse_struct::<TestStruct>(&invalid_json).is_err())
+    }
+
+    #[test]
+    fn test_recipient_addr_generate_msg_native() {
+        let deps = mock_dependencies(&[]);
+        let recipient = Recipient::Addr("address".to_string());
+        let funds = coins(100, "uusd");
+        let msg = recipient
+            .generate_msg_native(&deps.as_ref(), funds.clone())
+            .unwrap();
+        let expected_msg = SubMsg::new(CosmosMsg::Bank(BankMsg::Send {
+            to_address: "address".to_string(),
+            amount: funds,
+        }));
+        assert_eq!(expected_msg, msg);
+    }
+
+    #[test]
+    fn test_recipient_ado_generate_msg_native() {
+        let deps = mock_dependencies(&[]);
+        let recipient = Recipient::ADO(ADORecipient {
+            addr: "address".to_string(),
+            msg: None,
+        });
+        let funds = coins(100, "uusd");
+        let msg = recipient
+            .generate_msg_native(&deps.as_ref(), funds.clone())
+            .unwrap();
+        let expected_msg = SubMsg::new(WasmMsg::Execute {
+            contract_addr: "address".to_string(),
+            msg: encode_binary(&ExecuteMsg::AndrReceive(AndromedaMsg::Receive(None))).unwrap(),
+            funds,
+        });
+        assert_eq!(expected_msg, msg);
+    }
+
+    #[test]
+    fn test_recipient_addr_generate_msg_cw20() {
+        let deps = mock_dependencies(&[]);
+        let recipient = Recipient::Addr("address".to_string());
+        let cw20_coin = Cw20Coin {
+            amount: 100u128.into(),
+            address: "cw20_address".to_string(),
+        };
+        let msg = recipient
+            .generate_msg_cw20(&deps.as_ref(), cw20_coin.clone())
+            .unwrap();
+        let expected_msg = SubMsg::new(WasmMsg::Execute {
+            contract_addr: cw20_coin.address,
+            msg: encode_binary(&Cw20ExecuteMsg::Transfer {
+                recipient: "address".to_string(),
+                amount: cw20_coin.amount,
+            })
+            .unwrap(),
+            funds: vec![],
+        });
+        assert_eq!(expected_msg, msg);
+    }
+
+    #[test]
+    fn test_recipient_ado_generate_msg_cw20() {
+        let deps = mock_dependencies(&[]);
+        let recipient = Recipient::ADO(ADORecipient {
+            addr: "address".to_string(),
+            msg: None,
+        });
+        let cw20_coin = Cw20Coin {
+            amount: 100u128.into(),
+            address: "cw20_address".to_string(),
+        };
+        let msg = recipient
+            .generate_msg_cw20(&deps.as_ref(), cw20_coin.clone())
+            .unwrap();
+        let expected_msg = SubMsg::new(WasmMsg::Execute {
+            contract_addr: "cw20_address".to_string(),
+            msg: encode_binary(&Cw20ExecuteMsg::Send {
+                contract: "address".to_string(),
+                amount: cw20_coin.amount,
+                msg: encode_binary(&ExecuteMsg::AndrReceive(AndromedaMsg::Receive(None))).unwrap(),
+            })
+            .unwrap(),
+            funds: vec![],
+        });
+        assert_eq!(expected_msg, msg);
     }
 }

--- a/packages/andromeda_protocol/src/rates.rs
+++ b/packages/andromeda_protocol/src/rates.rs
@@ -2,9 +2,16 @@ use crate::{
     communication::{AndromedaMsg, AndromedaQuery, Recipient},
     modules::Rate,
 };
-use cosmwasm_std::SubMsg;
+use cosmwasm_std::{Coin, SubMsg};
+use cw20::Cw20Coin;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub enum Funds {
+    Native(Coin),
+    Cw20(Cw20Coin),
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
@@ -33,6 +40,7 @@ pub struct PaymentsResponse {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct DeductedFundsResponse {
     pub msgs: Vec<SubMsg>,
+    pub leftover_funds: Funds,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/andromeda_protocol/src/testing/mock_querier.rs
+++ b/packages/andromeda_protocol/src/testing/mock_querier.rs
@@ -84,6 +84,10 @@ impl WasmMockQuerier {
                         name: name.unwrap(),
                         value: Primitive::Coin(coin(1u128, "uusd")),
                     },
+                    "flat_cw20" => GetValueResponse {
+                        name: name.unwrap(),
+                        value: Primitive::Coin(coin(1u128, "address")),
+                    },
                     _ => panic!("Unsupported rate name"),
                 };
                 SystemResult::Ok(ContractResult::Ok(to_binary(&msg_response).unwrap()))

--- a/packages/andromeda_protocol/src/timelock.rs
+++ b/packages/andromeda_protocol/src/timelock.rs
@@ -276,8 +276,8 @@ mod tests {
         );
 
         let invalid_time_escrow = Escrow {
-            recipient: recipient.clone(),
-            coins: coins.clone(),
+            recipient,
+            coins,
             condition: Some(EscrowCondition::Expiration(Expiration::AtTime(
                 Timestamp::from_seconds(100),
             ))),
@@ -333,7 +333,7 @@ mod tests {
 
         // Duplicate funds
         let invalid_escrow = Escrow {
-            recipient: recipient.clone(),
+            recipient,
             coins: vec![coin(100, "uluna")],
             condition: Some(EscrowCondition::MinimumFunds(vec![
                 coin(100, "uusd"),
@@ -374,7 +374,7 @@ mod tests {
         assert!(escrow.min_funds_deposited(vec![coin(100, "uluna")]));
 
         let escrow = Escrow {
-            recipient: recipient.clone(),
+            recipient,
             coins: vec![coin(200, "uluna")],
             condition: None,
         };


### PR DESCRIPTION
I created an enum 
```
pub enum Funds {
    Native(Coin),
    Cw20(Cw20Coin),
}
```
to allow `query_deducted_funds` to use both native and cw20 funds. As such, I changed its signature to accept `Funds` instead of `Coin`. I also changed the response for that query to return the funds left over from any deductions in addition to the payment messages. 

For `Recipient`, the method `generate_msg` was renamed to `generate_msg_native` to differentiate from the new, similar, method `generate_msg_cw20`. This method currently returns a `Cw20ExecuteMsg::Transfer` for recipients of type `Addr` and a `Cw20ExecuteMsg::Send` for recipients of type `ADO`. For the ADO recipient, we don't currently have any cw20 hooks that support the communication protocol so what is there is mostly a placeholder and may change depending on how we want to structure that. 