### PR TITLE
Creation of Withdrawal ADO functionality and its implementation for mirror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,7 @@ dependencies = [
  "schemars",
  "serde",
  "terra-cosmwasm",
+ "terraswap",
  "thiserror",
 ]
 

--- a/contracts/andromeda_anchor/src/contract.rs
+++ b/contracts/andromeda_anchor/src/contract.rs
@@ -80,6 +80,7 @@ fn execute_andr_receive(
         AndromedaMsg::UpdateOperators { operators } => {
             execute_update_operators(deps, info, operators)
         }
+        AndromedaMsg::Withdraw { .. } => Err(ContractError::UnsupportedOperation {}),
     }
 }
 

--- a/contracts/andromeda_mirror_wrapped_cdp/src/contract.rs
+++ b/contracts/andromeda_mirror_wrapped_cdp/src/contract.rs
@@ -20,7 +20,7 @@ use andromeda_protocol::{
     },
     ownership::{execute_update_owner, is_contract_owner, query_contract_owner, CONTRACT_OWNER},
     require,
-    withdraw::{add_token, remove_token},
+    withdraw::{add_withdrawable_token, remove_withdrawable_token},
 };
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use terraswap::asset::{Asset, AssetInfo};
@@ -50,7 +50,7 @@ pub fn instantiate(
         .addr_validate(&msg.mirror_token_contract)?
         .to_string();
     // We will need to be able to withdraw the MIR token.
-    add_token(
+    add_withdrawable_token(
         deps.storage,
         &mirror_token_contract.clone(),
         &AssetInfo::Token {
@@ -159,7 +159,7 @@ fn execute_mirror_staking_msg(
             asset_token,
             amount: _,
         } => {
-            add_token(
+            add_withdrawable_token(
                 deps.storage,
                 &asset_token.clone(),
                 &AssetInfo::Token {
@@ -199,10 +199,10 @@ fn handle_open_position_tokens(
     is_short: bool,
 ) -> Result<(), ContractError> {
     // Barring liquidation we will want to withdraw the collateral at some point.
-    add_token(storage, &get_asset_name(&collateral_info), &collateral_info)?;
+    add_withdrawable_token(storage, &get_asset_name(&collateral_info), &collateral_info)?;
     if is_short {
         // If we are shorting we will get UST back eventually.
-        add_token(
+        add_withdrawable_token(
             storage,
             "uusd",
             &AssetInfo::NativeToken {
@@ -212,7 +212,7 @@ fn handle_open_position_tokens(
     } else {
         // In this case the minted assets will be immediatly sent back to this contract, so
         // we want to be able to withdraw it.
-        add_token(
+        add_withdrawable_token(
             storage,
             &get_asset_name(&minted_asset_info),
             &minted_asset_info,

--- a/contracts/andromeda_mirror_wrapped_cdp/src/contract.rs
+++ b/contracts/andromeda_mirror_wrapped_cdp/src/contract.rs
@@ -20,7 +20,7 @@ use andromeda_protocol::{
     },
     ownership::{execute_update_owner, is_contract_owner, query_contract_owner, CONTRACT_OWNER},
     require,
-    withdraw::{add_withdrawable_token, remove_withdrawable_token},
+    withdraw::{add_withdrawable_token, execute_withdraw},
 };
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use terraswap::asset::{Asset, AssetInfo};
@@ -238,6 +238,9 @@ fn execute_andr_receive(
         AndromedaMsg::UpdateOwner { address } => execute_update_owner(deps, info, address),
         AndromedaMsg::UpdateOperators { operators } => {
             execute_update_operators(deps, info, operators)
+        }
+        AndromedaMsg::Withdraw { recipient } => {
+            execute_withdraw(deps.as_ref(), env, info, recipient)
         }
     }
 }

--- a/contracts/andromeda_mirror_wrapped_cdp/src/contract.rs
+++ b/contracts/andromeda_mirror_wrapped_cdp/src/contract.rs
@@ -267,9 +267,10 @@ fn execute_andr_receive(
         AndromedaMsg::UpdateOperators { operators } => {
             execute_update_operators(deps, info, operators)
         }
-        AndromedaMsg::Withdraw { recipient } => {
-            execute_withdraw(deps.as_ref(), env, info, recipient)
-        }
+        AndromedaMsg::Withdraw {
+            recipient,
+            tokens_to_withdraw,
+        } => execute_withdraw(deps.as_ref(), env, info, recipient, tokens_to_withdraw),
     }
 }
 

--- a/contracts/andromeda_mirror_wrapped_cdp/src/contract.rs
+++ b/contracts/andromeda_mirror_wrapped_cdp/src/contract.rs
@@ -116,7 +116,7 @@ fn execute_mirror_mint_msg(
             collateral_ratio: _,
             short_params,
         } => {
-            handle_open_position_tokens(
+            handle_open_position_withdrawable_tokens(
                 deps.storage,
                 collateral.info,
                 asset_info,
@@ -220,7 +220,7 @@ fn get_asset_name(asset_info: &AssetInfo) -> String {
     }
 }
 
-fn handle_open_position_tokens(
+fn handle_open_position_withdrawable_tokens(
     storage: &mut dyn Storage,
     collateral_info: AssetInfo,
     minted_asset_info: AssetInfo,
@@ -238,7 +238,7 @@ fn handle_open_position_tokens(
             },
         )?;
     } else {
-        // In this case the minted assets will be immediatly sent back to this contract, so
+        // In this case the minted assets will be immediately sent back to this contract, so
         // we want to be able to withdraw it.
         add_withdrawable_token(
             storage,
@@ -318,7 +318,7 @@ fn execute_mirror_mint_cw20_msg(
             collateral_ratio: _,
             short_params,
         } => {
-            handle_open_position_tokens(
+            handle_open_position_withdrawable_tokens(
                 deps.storage,
                 AssetInfo::Token {
                     contract_addr: token_address.clone(),

--- a/contracts/andromeda_mirror_wrapped_cdp/src/contract.rs
+++ b/contracts/andromeda_mirror_wrapped_cdp/src/contract.rs
@@ -2,7 +2,7 @@
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     from_binary, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
-    Uint128, WasmMsg,
+    Storage, Uint128, WasmMsg,
 };
 use cw2::set_contract_version;
 
@@ -10,13 +10,17 @@ use crate::state::{Config, CONFIG};
 use andromeda_protocol::{
     communication::{encode_binary, parse_message, AndromedaMsg, AndromedaQuery},
     error::ContractError,
-    mirror_wrapped_cdp::{ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg},
+    mirror_wrapped_cdp::{
+        ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, MirrorMintCw20HookMsg,
+        MirrorMintExecuteMsg, MirrorStakingExecuteMsg, QueryMsg,
+    },
     operators::{
         execute_update_operators, initialize_operators, is_operator, query_is_operator,
         query_operators,
     },
     ownership::{execute_update_owner, is_contract_owner, query_contract_owner, CONTRACT_OWNER},
     require,
+    withdraw::{add_token, remove_token},
 };
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use terraswap::asset::{Asset, AssetInfo};
@@ -41,6 +45,18 @@ pub fn instantiate(
         mirror_gov_contract: deps.api.addr_validate(&msg.mirror_gov_contract)?,
         mirror_lock_contract: deps.api.addr_validate(&msg.mirror_lock_contract)?,
     };
+    let mirror_token_contract = deps
+        .api
+        .addr_validate(&msg.mirror_token_contract)?
+        .to_string();
+    // We will need to be able to withdraw the MIR token.
+    add_token(
+        deps.storage,
+        &mirror_token_contract.clone(),
+        &AssetInfo::Token {
+            contract_addr: mirror_token_contract,
+        },
+    )?;
     CONFIG.save(deps.storage, &config)?;
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     CONTRACT_OWNER.save(deps.storage, &info.sender)?;
@@ -60,20 +76,8 @@ pub fn execute(
     match msg {
         ExecuteMsg::AndrReceive(msg) => execute_andr_receive(deps, env, info, msg),
         ExecuteMsg::Receive(msg) => receive_cw20(deps, info, msg),
-        ExecuteMsg::MirrorMintExecuteMsg(msg) => execute_mirror_msg(
-            deps,
-            info.sender.to_string(),
-            info.funds,
-            config.mirror_mint_contract.to_string(),
-            encode_binary(&msg)?,
-        ),
-        ExecuteMsg::MirrorStakingExecuteMsg(msg) => execute_mirror_msg(
-            deps,
-            info.sender.to_string(),
-            info.funds,
-            config.mirror_staking_contract.to_string(),
-            encode_binary(&msg)?,
-        ),
+        ExecuteMsg::MirrorMintExecuteMsg(msg) => execute_mirror_mint_msg(deps, info, msg),
+        ExecuteMsg::MirrorStakingExecuteMsg(msg) => execute_mirror_staking_msg(deps, info, msg),
         ExecuteMsg::MirrorGovExecuteMsg(msg) => execute_mirror_msg(
             deps,
             info.sender.to_string(),
@@ -102,6 +106,119 @@ pub fn execute(
             mirror_lock_contract,
         ),
     }
+}
+
+fn execute_mirror_mint_msg(
+    deps: DepsMut,
+    info: MessageInfo,
+    msg: MirrorMintExecuteMsg,
+) -> Result<Response, ContractError> {
+    let config = CONFIG.load(deps.storage)?;
+    let binary = encode_binary(&msg)?;
+    match msg {
+        MirrorMintExecuteMsg::OpenPosition {
+            collateral,
+            asset_info,
+            collateral_ratio: _,
+            short_params,
+        } => {
+            handle_open_position_tokens(
+                deps.storage,
+                collateral.info,
+                asset_info,
+                short_params.is_some(),
+            )?;
+
+            execute_mirror_msg(
+                deps,
+                info.sender.to_string(),
+                info.funds,
+                config.mirror_mint_contract.to_string(),
+                binary,
+            )
+        }
+        _ => execute_mirror_msg(
+            deps,
+            info.sender.to_string(),
+            info.funds,
+            config.mirror_mint_contract.to_string(),
+            binary,
+        ),
+    }
+}
+
+fn execute_mirror_staking_msg(
+    deps: DepsMut,
+    info: MessageInfo,
+    msg: MirrorStakingExecuteMsg,
+) -> Result<Response, ContractError> {
+    let config = CONFIG.load(deps.storage)?;
+    let binary = encode_binary(&msg)?;
+    match msg {
+        MirrorStakingExecuteMsg::Unbond {
+            asset_token,
+            amount: _,
+        } => {
+            add_token(
+                deps.storage,
+                &asset_token.clone(),
+                &AssetInfo::Token {
+                    contract_addr: asset_token,
+                },
+            )?;
+
+            execute_mirror_msg(
+                deps,
+                info.sender.to_string(),
+                info.funds,
+                config.mirror_staking_contract.to_string(),
+                binary,
+            )
+        }
+        _ => execute_mirror_msg(
+            deps,
+            info.sender.to_string(),
+            info.funds,
+            config.mirror_staking_contract.to_string(),
+            binary,
+        ),
+    }
+}
+
+fn get_asset_name(asset_info: &AssetInfo) -> String {
+    match asset_info {
+        AssetInfo::Token { contract_addr } => contract_addr.clone(),
+        AssetInfo::NativeToken { denom } => denom.clone(),
+    }
+}
+
+fn handle_open_position_tokens(
+    storage: &mut dyn Storage,
+    collateral_info: AssetInfo,
+    minted_asset_info: AssetInfo,
+    is_short: bool,
+) -> Result<(), ContractError> {
+    // Barring liquidation we will want to withdraw the collateral at some point.
+    add_token(storage, &get_asset_name(&collateral_info), &collateral_info)?;
+    if is_short {
+        // If we are shorting we will get UST back eventually.
+        add_token(
+            storage,
+            "uusd",
+            &AssetInfo::NativeToken {
+                denom: "uusd".to_string(),
+            },
+        )?;
+    } else {
+        // In this case the minted assets will be immediatly sent back to this contract, so
+        // we want to be able to withdraw it.
+        add_token(
+            storage,
+            &get_asset_name(&minted_asset_info),
+            &minted_asset_info,
+        )?;
+    }
+    Ok(())
 }
 
 fn execute_andr_receive(
@@ -133,14 +250,9 @@ pub fn receive_cw20(
     let config = CONFIG.load(deps.storage)?;
     let token_address = info.sender.to_string();
     match from_binary(&cw20_msg.msg)? {
-        Cw20HookMsg::MirrorMintCw20HookMsg(msg) => execute_mirror_cw20_msg(
-            deps,
-            cw20_msg.sender,
-            token_address,
-            cw20_msg.amount,
-            config.mirror_mint_contract.to_string(),
-            encode_binary(&msg)?,
-        ),
+        Cw20HookMsg::MirrorMintCw20HookMsg(msg) => {
+            execute_mirror_mint_cw20_msg(deps, info, cw20_msg, msg)
+        }
         Cw20HookMsg::MirrorStakingCw20HookMsg(msg) => execute_mirror_cw20_msg(
             deps,
             cw20_msg.sender,
@@ -156,6 +268,49 @@ pub fn receive_cw20(
             cw20_msg.amount,
             config.mirror_gov_contract.to_string(),
             encode_binary(&msg)?,
+        ),
+    }
+}
+
+fn execute_mirror_mint_cw20_msg(
+    deps: DepsMut,
+    info: MessageInfo,
+    cw20_msg: Cw20ReceiveMsg,
+    mirror_msg: MirrorMintCw20HookMsg,
+) -> Result<Response, ContractError> {
+    let config = CONFIG.load(deps.storage)?;
+    let token_address = info.sender.to_string();
+    let binary = encode_binary(&mirror_msg)?;
+    match mirror_msg {
+        MirrorMintCw20HookMsg::OpenPosition {
+            asset_info,
+            collateral_ratio: _,
+            short_params,
+        } => {
+            handle_open_position_tokens(
+                deps.storage,
+                AssetInfo::Token {
+                    contract_addr: token_address.clone(),
+                },
+                asset_info,
+                short_params.is_some(),
+            )?;
+            execute_mirror_cw20_msg(
+                deps,
+                cw20_msg.sender,
+                token_address,
+                cw20_msg.amount,
+                config.mirror_mint_contract.to_string(),
+                binary,
+            )
+        }
+        _ => execute_mirror_cw20_msg(
+            deps,
+            cw20_msg.sender,
+            token_address,
+            cw20_msg.amount,
+            config.mirror_mint_contract.to_string(),
+            binary,
         ),
     }
 }

--- a/contracts/andromeda_mirror_wrapped_cdp/src/testing/tests.rs
+++ b/contracts/andromeda_mirror_wrapped_cdp/src/testing/tests.rs
@@ -23,6 +23,7 @@ use terraswap::asset::{Asset, AssetInfo};
 
 const TEST_TOKEN: &str = "TEST_TOKEN";
 const TEST_AMOUNT: u128 = 100u128;
+const MOCK_MIRROR_TOKEN_ADDR: &str = "mirror_token";
 const MOCK_MIRROR_MINT_ADDR: &str = "mirror_mint";
 const MOCK_MIRROR_STAKING_ADDR: &str = "mirror_staking";
 const MOCK_MIRROR_GOV_ADDR: &str = "mirror_gov";
@@ -177,6 +178,7 @@ fn assert_query_msg<T: DeserializeOwned + Debug + PartialEq>(
 
 fn assert_intantiate(deps: DepsMut, info: MessageInfo) {
     let msg = InstantiateMsg {
+        mirror_token_contract: MOCK_MIRROR_TOKEN_ADDR.to_string(),
         mirror_mint_contract: MOCK_MIRROR_MINT_ADDR.to_string(),
         mirror_staking_contract: MOCK_MIRROR_STAKING_ADDR.to_string(),
         mirror_gov_contract: MOCK_MIRROR_GOV_ADDR.to_string(),
@@ -218,6 +220,7 @@ fn test_instantiate_with_operator() {
     let info = mock_info("creator", &[]);
     let operator = mock_info("operator", &[]);
     let msg = InstantiateMsg {
+        mirror_token_contract: MOCK_MIRROR_TOKEN_ADDR.to_string(),
         mirror_mint_contract: MOCK_MIRROR_MINT_ADDR.to_string(),
         mirror_staking_contract: MOCK_MIRROR_STAKING_ADDR.to_string(),
         mirror_gov_contract: MOCK_MIRROR_GOV_ADDR.to_string(),

--- a/contracts/andromeda_mirror_wrapped_cdp/src/testing/tests.rs
+++ b/contracts/andromeda_mirror_wrapped_cdp/src/testing/tests.rs
@@ -9,14 +9,15 @@ use andromeda_protocol::{
         MirrorStakingCw20HookMsg, MirrorStakingExecuteMsg, QueryMsg,
     },
     operators::OperatorsResponse,
+    withdraw::WITHDRAWABLE_TOKENS,
 };
 use cosmwasm_std::testing::{mock_env, mock_info};
 use cosmwasm_std::{
     coin, coins, from_binary, to_binary, Binary, CosmosMsg, Decimal, Deps, DepsMut, MessageInfo,
-    Response, Uint128, WasmMsg,
+    Order, Response, Uint128, WasmMsg,
 };
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
-use mirror_protocol::gov::VoteOption;
+use mirror_protocol::{gov::VoteOption, mint::ShortParams};
 use serde::de::DeserializeOwned;
 use std::fmt::Debug;
 use terraswap::asset::{Asset, AssetInfo};
@@ -212,6 +213,22 @@ fn test_instantiate() {
             mirror_lock_contract: MOCK_MIRROR_LOCK_ADDR.to_string(),
         },
     );
+    assert_eq!(
+        1,
+        WITHDRAWABLE_TOKENS
+            .keys(deps.as_mut().storage, None, None, Order::Ascending)
+            .collect::<Vec<Vec<u8>>>()
+            .len()
+    );
+
+    assert_eq!(
+        AssetInfo::Token {
+            contract_addr: MOCK_MIRROR_TOKEN_ADDR.to_string()
+        },
+        WITHDRAWABLE_TOKENS
+            .load(deps.as_mut().storage, MOCK_MIRROR_TOKEN_ADDR)
+            .unwrap()
+    );
 }
 
 #[test]
@@ -239,15 +256,15 @@ fn test_instantiate_with_operator() {
 }
 
 #[test]
-fn test_mirror_mint_open_position() {
+fn test_mirror_mint_open_position_not_short() {
     let mut deps = mock_dependencies_custom(&[]);
     let info = mock_info("creator", &[]);
     assert_intantiate(deps.as_mut(), info.clone());
 
     let mirror_msg = MirrorMintExecuteMsg::OpenPosition {
         collateral: Asset {
-            info: AssetInfo::NativeToken {
-                denom: "uusd".to_string(),
+            info: AssetInfo::Token {
+                contract_addr: "collateral_token".to_string(),
             },
             amount: Uint128::from(10_u128),
         },
@@ -258,6 +275,79 @@ fn test_mirror_mint_open_position() {
         short_params: None,
     };
     assert_mint_execute_msg(deps.as_mut(), info, mirror_msg);
+
+    assert_eq!(
+        AssetInfo::Token {
+            contract_addr: "collateral_token".to_string()
+        },
+        WITHDRAWABLE_TOKENS
+            .load(deps.as_mut().storage, "collateral_token")
+            .unwrap()
+    );
+    assert_eq!(
+        AssetInfo::Token {
+            contract_addr: "token_address".to_string()
+        },
+        WITHDRAWABLE_TOKENS
+            .load(deps.as_mut().storage, "token_address")
+            .unwrap()
+    );
+    assert_eq!(
+        3,
+        WITHDRAWABLE_TOKENS
+            .keys(deps.as_mut().storage, None, None, Order::Ascending)
+            .collect::<Vec<Vec<u8>>>()
+            .len()
+    );
+}
+
+#[test]
+fn test_mirror_mint_open_position_short() {
+    let mut deps = mock_dependencies_custom(&[]);
+    let info = mock_info("creator", &[]);
+    assert_intantiate(deps.as_mut(), info.clone());
+
+    let mirror_msg = MirrorMintExecuteMsg::OpenPosition {
+        collateral: Asset {
+            info: AssetInfo::Token {
+                contract_addr: "collateral_token".to_string(),
+            },
+            amount: Uint128::from(10_u128),
+        },
+        asset_info: AssetInfo::Token {
+            contract_addr: "token_address".to_string(),
+        },
+        collateral_ratio: Decimal::one(),
+        short_params: Some(ShortParams {
+            belief_price: None,
+            max_spread: None,
+        }),
+    };
+    assert_mint_execute_msg(deps.as_mut(), info, mirror_msg);
+
+    assert_eq!(
+        AssetInfo::Token {
+            contract_addr: "collateral_token".to_string()
+        },
+        WITHDRAWABLE_TOKENS
+            .load(deps.as_mut().storage, "collateral_token")
+            .unwrap()
+    );
+    assert_eq!(
+        AssetInfo::NativeToken {
+            denom: "uusd".to_string()
+        },
+        WITHDRAWABLE_TOKENS
+            .load(deps.as_mut().storage, "uusd")
+            .unwrap()
+    );
+    assert_eq!(
+        3,
+        WITHDRAWABLE_TOKENS
+            .keys(deps.as_mut().storage, None, None, Order::Ascending)
+            .collect::<Vec<Vec<u8>>>()
+            .len()
+    );
 }
 
 #[test]
@@ -329,20 +419,88 @@ fn test_mirror_mint_mint() {
 }
 
 #[test]
-fn test_mirror_mint_open_position_cw20() {
+fn test_mirror_mint_open_position_cw20_not_short() {
     let mut deps = mock_dependencies_custom(&[]);
     let info = mock_info("creator", &[]);
     assert_intantiate(deps.as_mut(), info.clone());
 
     let mirror_msg = MirrorMintCw20HookMsg::OpenPosition {
         asset_info: AssetInfo::Token {
-            contract_addr: TEST_TOKEN.to_string(),
+            contract_addr: "minted_asset_token".to_string(),
         },
         collateral_ratio: Decimal::one(),
         short_params: None,
     };
 
     assert_mint_execute_cw20_msg(deps.as_mut(), info, mirror_msg);
+
+    assert_eq!(
+        AssetInfo::Token {
+            contract_addr: "minted_asset_token".to_string()
+        },
+        WITHDRAWABLE_TOKENS
+            .load(deps.as_mut().storage, "minted_asset_token")
+            .unwrap()
+    );
+    assert_eq!(
+        AssetInfo::Token {
+            contract_addr: TEST_TOKEN.to_string()
+        },
+        WITHDRAWABLE_TOKENS
+            .load(deps.as_mut().storage, TEST_TOKEN)
+            .unwrap()
+    );
+    assert_eq!(
+        3,
+        WITHDRAWABLE_TOKENS
+            .keys(deps.as_mut().storage, None, None, Order::Ascending)
+            .collect::<Vec<Vec<u8>>>()
+            .len()
+    );
+}
+
+#[test]
+fn test_mirror_mint_open_position_cw20_short() {
+    let mut deps = mock_dependencies_custom(&[]);
+    let info = mock_info("creator", &[]);
+    assert_intantiate(deps.as_mut(), info.clone());
+
+    let mirror_msg = MirrorMintCw20HookMsg::OpenPosition {
+        asset_info: AssetInfo::Token {
+            contract_addr: "minted_asset_token".to_string(),
+        },
+        collateral_ratio: Decimal::one(),
+        short_params: Some(ShortParams {
+            belief_price: None,
+            max_spread: None,
+        }),
+    };
+
+    assert_mint_execute_cw20_msg(deps.as_mut(), info, mirror_msg);
+
+    assert_eq!(
+        AssetInfo::NativeToken {
+            denom: "uusd".to_string()
+        },
+        WITHDRAWABLE_TOKENS
+            .load(deps.as_mut().storage, "uusd")
+            .unwrap()
+    );
+    assert_eq!(
+        AssetInfo::Token {
+            contract_addr: TEST_TOKEN.to_string()
+        },
+        WITHDRAWABLE_TOKENS
+            .load(deps.as_mut().storage, TEST_TOKEN)
+            .unwrap()
+    );
+    assert_eq!(
+        3,
+        WITHDRAWABLE_TOKENS
+            .keys(deps.as_mut().storage, None, None, Order::Ascending)
+            .collect::<Vec<Vec<u8>>>()
+            .len()
+    );
 }
 
 #[test]
@@ -407,6 +565,22 @@ fn test_mirror_staking_unbond() {
     };
 
     assert_staking_execute_msg(deps.as_mut(), info, mirror_msg);
+
+    assert_eq!(
+        AssetInfo::Token {
+            contract_addr: "asset_token".to_string()
+        },
+        WITHDRAWABLE_TOKENS
+            .load(deps.as_mut().storage, "asset_token")
+            .unwrap()
+    );
+    assert_eq!(
+        2,
+        WITHDRAWABLE_TOKENS
+            .keys(deps.as_mut().storage, None, None, Order::Ascending)
+            .collect::<Vec<Vec<u8>>>()
+            .len()
+    );
 }
 
 #[test]
@@ -578,6 +752,22 @@ fn test_lock_unlock_position_funds() {
         positions_idx: vec![Uint128::from(1u128)],
     };
     assert_lock_execute_msg(deps.as_mut(), info, mirror_msg);
+
+    assert_eq!(
+        AssetInfo::NativeToken {
+            denom: "uusd".to_string()
+        },
+        WITHDRAWABLE_TOKENS
+            .load(deps.as_mut().storage, "uusd")
+            .unwrap()
+    );
+    assert_eq!(
+        2,
+        WITHDRAWABLE_TOKENS
+            .keys(deps.as_mut().storage, None, None, Order::Ascending)
+            .collect::<Vec<Vec<u8>>>()
+            .len()
+    );
 }
 
 #[test]

--- a/contracts/andromeda_mirror_wrapped_cdp/src/testing/tests.rs
+++ b/contracts/andromeda_mirror_wrapped_cdp/src/testing/tests.rs
@@ -217,8 +217,7 @@ fn test_instantiate() {
         1,
         WITHDRAWABLE_TOKENS
             .keys(deps.as_mut().storage, None, None, Order::Ascending)
-            .collect::<Vec<Vec<u8>>>()
-            .len()
+            .count()
     );
 
     assert_eq!(
@@ -296,8 +295,7 @@ fn test_mirror_mint_open_position_not_short() {
         3,
         WITHDRAWABLE_TOKENS
             .keys(deps.as_mut().storage, None, None, Order::Ascending)
-            .collect::<Vec<Vec<u8>>>()
-            .len()
+            .count()
     );
 }
 
@@ -345,8 +343,7 @@ fn test_mirror_mint_open_position_short() {
         3,
         WITHDRAWABLE_TOKENS
             .keys(deps.as_mut().storage, None, None, Order::Ascending)
-            .collect::<Vec<Vec<u8>>>()
-            .len()
+            .count()
     );
 }
 
@@ -454,8 +451,7 @@ fn test_mirror_mint_open_position_cw20_not_short() {
         3,
         WITHDRAWABLE_TOKENS
             .keys(deps.as_mut().storage, None, None, Order::Ascending)
-            .collect::<Vec<Vec<u8>>>()
-            .len()
+            .count()
     );
 }
 
@@ -498,8 +494,7 @@ fn test_mirror_mint_open_position_cw20_short() {
         3,
         WITHDRAWABLE_TOKENS
             .keys(deps.as_mut().storage, None, None, Order::Ascending)
-            .collect::<Vec<Vec<u8>>>()
-            .len()
+            .count()
     );
 }
 
@@ -578,8 +573,7 @@ fn test_mirror_staking_unbond() {
         2,
         WITHDRAWABLE_TOKENS
             .keys(deps.as_mut().storage, None, None, Order::Ascending)
-            .collect::<Vec<Vec<u8>>>()
-            .len()
+            .count()
     );
 }
 
@@ -765,8 +759,7 @@ fn test_lock_unlock_position_funds() {
         2,
         WITHDRAWABLE_TOKENS
             .keys(deps.as_mut().storage, None, None, Order::Ascending)
-            .collect::<Vec<Vec<u8>>>()
-            .len()
+            .count()
     );
 }
 

--- a/contracts/andromeda_primitive/src/contract.rs
+++ b/contracts/andromeda_primitive/src/contract.rs
@@ -67,6 +67,7 @@ fn execute_receive(
         AndromedaMsg::UpdateOperators { operators } => {
             execute_update_operators(deps, info, operators)
         }
+        AndromedaMsg::Withdraw { .. } => Err(ContractError::UnsupportedOperation {}),
     }
 }
 

--- a/contracts/andromeda_rates/src/contract.rs
+++ b/contracts/andromeda_rates/src/contract.rs
@@ -56,6 +56,7 @@ fn execute_andr_receive(
         AndromedaMsg::UpdateOperators { operators } => {
             execute_update_operators(deps, info, operators)
         }
+        AndromedaMsg::Withdraw { .. } => Err(ContractError::UnsupportedOperation {}),
     }
 }
 

--- a/contracts/andromeda_receipt/src/contract.rs
+++ b/contracts/andromeda_receipt/src/contract.rs
@@ -67,6 +67,7 @@ fn execute_andr_receive(
         AndromedaMsg::UpdateOperators { operators } => {
             execute_update_operators(deps, info, operators)
         }
+        AndromedaMsg::Withdraw { .. } => Err(ContractError::UnsupportedOperation {}),
     }
 }
 

--- a/contracts/andromeda_splitter/src/contract.rs
+++ b/contracts/andromeda_splitter/src/contract.rs
@@ -96,6 +96,7 @@ pub fn execute_andromeda(
         AndromedaMsg::UpdateOperators { operators } => {
             execute_update_operators(deps, info, operators)
         }
+        AndromedaMsg::Withdraw { .. } => Err(ContractError::UnsupportedOperation {}),
     }
 }
 

--- a/contracts/andromeda_timelock/src/contract.rs
+++ b/contracts/andromeda_timelock/src/contract.rs
@@ -114,6 +114,7 @@ fn execute_receive(
         AndromedaMsg::UpdateOperators { operators } => {
             execute_update_operators(deps, info, operators)
         }
+        AndromedaMsg::Withdraw { .. } => Err(ContractError::UnsupportedOperation {}),
     }
 }
 

--- a/contracts/andromeda_token/src/contract.rs
+++ b/contracts/andromeda_token/src/contract.rs
@@ -156,6 +156,7 @@ fn execute_andr_receive(
         AndromedaMsg::UpdateOperators { operators } => {
             execute_update_operators(deps, info, operators)
         }
+        AndromedaMsg::Withdraw { .. } => Err(ContractError::UnsupportedOperation {}),
     }
 }
 

--- a/packages/andromeda_protocol/Cargo.toml
+++ b/packages/andromeda_protocol/Cargo.toml
@@ -23,3 +23,4 @@ mirror-protocol = "2.1.1"
 cw20 = { version = "0.9.1" }
 cw0 = "0.9.1"
 cw20-base = "0.9.1"
+terraswap = {version = "2.4.0"}

--- a/packages/andromeda_protocol/src/communication/mod.rs
+++ b/packages/andromeda_protocol/src/communication/mod.rs
@@ -98,6 +98,7 @@ pub enum AndromedaMsg {
     Receive(Option<Binary>),
     UpdateOwner { address: String },
     UpdateOperators { operators: Vec<String> },
+    Withdraw { recipient: Recipient },
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/packages/andromeda_protocol/src/communication/mod.rs
+++ b/packages/andromeda_protocol/src/communication/mod.rs
@@ -96,9 +96,16 @@ impl Recipient {
 #[serde(rename_all = "snake_case")]
 pub enum AndromedaMsg {
     Receive(Option<Binary>),
-    UpdateOwner { address: String },
-    UpdateOperators { operators: Vec<String> },
-    Withdraw { recipient: Recipient },
+    UpdateOwner {
+        address: String,
+    },
+    UpdateOperators {
+        operators: Vec<String>,
+    },
+    Withdraw {
+        recipient: Recipient,
+        tokens_to_withdraw: Option<Vec<String>>,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/packages/andromeda_protocol/src/error.rs
+++ b/packages/andromeda_protocol/src/error.rs
@@ -138,6 +138,8 @@ pub enum ContractError {
     #[error("Invalid png header")]
     InvalidPngHeader {},
     // END CW20 ERRORS
+    #[error("UnsupportedOperation")]
+    UnsupportedOperation {},
 }
 
 impl From<Cw20ContractError> for ContractError {

--- a/packages/andromeda_protocol/src/lib.rs
+++ b/packages/andromeda_protocol/src/lib.rs
@@ -16,6 +16,7 @@ pub mod rates;
 pub mod receipt;
 pub mod response;
 pub mod splitter;
+pub mod withdraw;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod testing;

--- a/packages/andromeda_protocol/src/mirror_wrapped_cdp.rs
+++ b/packages/andromeda_protocol/src/mirror_wrapped_cdp.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
+    pub mirror_token_contract: String,
     pub mirror_mint_contract: String,
     pub mirror_staking_contract: String,
     pub mirror_gov_contract: String,

--- a/packages/andromeda_protocol/src/testing/mock_querier.rs
+++ b/packages/andromeda_protocol/src/testing/mock_querier.rs
@@ -9,9 +9,11 @@ use cosmwasm_std::{
     to_binary, Binary, Coin, ContractResult, OwnedDeps, Querier, QuerierResult, QueryRequest,
     SystemError, SystemResult, WasmQuery,
 };
+use cw20::{BalanceResponse, Cw20QueryMsg};
 use terra_cosmwasm::TerraQueryWrapper;
 
 pub const MOCK_PRIMITIVE_CONTRACT: &str = "primitive_contract";
+pub const MOCK_CW20_CONTRACT: &str = "cw20_contract";
 
 pub fn mock_dependencies_custom(
     contract_balance: &[Coin],
@@ -61,6 +63,7 @@ impl WasmMockQuerier {
                         };
                         SystemResult::Ok(ContractResult::Ok(to_binary(&msg_response).unwrap()))
                     }
+                    MOCK_CW20_CONTRACT => self.handle_cw20_query(msg),
                     MOCK_PRIMITIVE_CONTRACT => self.handle_primitive_query(msg),
                     _ => {
                         let msg_response = IncludesAddressResponse { included: false };
@@ -69,6 +72,18 @@ impl WasmMockQuerier {
                 }
             }
             _ => self.base.handle_query(request),
+        }
+    }
+
+    fn handle_cw20_query(&self, msg: &Binary) -> QuerierResult {
+        match from_binary(msg).unwrap() {
+            Cw20QueryMsg::Balance { .. } => {
+                let balance_response = BalanceResponse {
+                    balance: 10u128.into(),
+                };
+                SystemResult::Ok(ContractResult::Ok(to_binary(&balance_response).unwrap()))
+            }
+            _ => panic!("Unsupported Query"),
         }
     }
 

--- a/packages/andromeda_protocol/src/withdraw.rs
+++ b/packages/andromeda_protocol/src/withdraw.rs
@@ -1,0 +1,22 @@
+use cosmwasm_std::{attr, Addr, Deps, DepsMut, MessageInfo, Response, StdResult, Storage};
+use cw_storage_plus::Map;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::error::ContractError;
+use crate::require;
+use terraswap::asset::AssetInfo;
+
+pub const WITHDRAWABLE_TOKENS: Map<&str, AssetInfo> = Map::new("withdrawable_tokens");
+
+pub fn add_token(
+    storage: &mut dyn Storage,
+    name: &str,
+    asset_info: AssetInfo,
+) -> Result<(), ContractError> {
+    Ok(WITHDRAWABLE_TOKENS.save(storage, name, &asset_info)?)
+}
+
+pub fn remove_token(storage: &mut dyn Storage, name: &str) -> Result<(), ContractError> {
+    Ok(WITHDRAWABLE_TOKENS.remove(storage, name))
+}

--- a/packages/andromeda_protocol/src/withdraw.rs
+++ b/packages/andromeda_protocol/src/withdraw.rs
@@ -18,7 +18,10 @@ pub fn add_withdrawable_token(
     name: &str,
     asset_info: &AssetInfo,
 ) -> Result<(), ContractError> {
-    Ok(WITHDRAWABLE_TOKENS.save(storage, name, asset_info)?)
+    if !WITHDRAWABLE_TOKENS.has(storage, name) {
+        WITHDRAWABLE_TOKENS.save(storage, name, asset_info)?;
+    }
+    Ok(())
 }
 
 pub fn remove_withdrawable_token(

--- a/packages/andromeda_protocol/src/withdraw.rs
+++ b/packages/andromeda_protocol/src/withdraw.rs
@@ -1,11 +1,6 @@
-use cosmwasm_std::{
-    attr, coin, Addr, Deps, DepsMut, Env, MessageInfo, Order, Response, StdResult, Storage, SubMsg,
-    Uint128,
-};
+use cosmwasm_std::{coin, Deps, Env, MessageInfo, Order, Response, Storage, SubMsg};
 use cw20::Cw20Coin;
 use cw_storage_plus::Map;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 use crate::{
     communication::Recipient, error::ContractError, operators::is_operator,
@@ -69,8 +64,8 @@ pub fn execute_withdraw(
             AssetInfo::Token { contract_addr } => {
                 let balance = query_token_balance(
                     &deps.querier,
-                    env.contract.address.clone(),
                     deps.api.addr_validate(&contract_addr)?,
+                    env.contract.address.clone(),
                 )?;
                 if balance.is_zero() {
                     None
@@ -96,7 +91,129 @@ pub fn execute_withdraw(
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::testing::{mock_dependencies, mock_info};
-
     use super::*;
+    use crate::{
+        operators::OPERATORS,
+        ownership::CONTRACT_OWNER,
+        testing::mock_querier::{mock_dependencies_custom, MOCK_CW20_CONTRACT},
+    };
+    use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+    use cosmwasm_std::{to_binary, Addr, BankMsg, CosmosMsg, SubMsg, WasmMsg};
+    use cw20::Cw20ExecuteMsg;
+
+    #[test]
+    fn test_execute_withdraw_not_authorized() {
+        let mut deps = mock_dependencies(&[]);
+        let owner = "owner";
+        CONTRACT_OWNER
+            .save(deps.as_mut().storage, &Addr::unchecked(owner))
+            .unwrap();
+        let info = mock_info("not_owner", &[]);
+        let res = execute_withdraw(
+            deps.as_ref(),
+            mock_env(),
+            info,
+            Recipient::Addr("address".to_string()),
+        );
+        assert_eq!(ContractError::Unauthorized {}, res.unwrap_err());
+    }
+
+    #[test]
+    fn test_execute_withdraw_no_funds() {
+        let mut deps = mock_dependencies(&[]);
+        let owner = "owner";
+        CONTRACT_OWNER
+            .save(deps.as_mut().storage, &Addr::unchecked(owner))
+            .unwrap();
+        let info = mock_info(owner, &[]);
+        let res = execute_withdraw(
+            deps.as_ref(),
+            mock_env(),
+            info,
+            Recipient::Addr("address".to_string()),
+        );
+        assert_eq!(ContractError::EmptyFunds {}, res.unwrap_err());
+    }
+
+    #[test]
+    fn test_execute_withdraw_native() {
+        let mut deps = mock_dependencies(&[coin(100, "uusd")]);
+        let owner = "owner";
+        CONTRACT_OWNER
+            .save(deps.as_mut().storage, &Addr::unchecked(owner))
+            .unwrap();
+        let info = mock_info(owner, &[]);
+        WITHDRAWABLE_TOKENS
+            .save(
+                deps.as_mut().storage,
+                "uusd",
+                &AssetInfo::NativeToken {
+                    denom: "uusd".into(),
+                },
+            )
+            .unwrap();
+        let res = execute_withdraw(
+            deps.as_ref(),
+            mock_env(),
+            info,
+            Recipient::Addr("address".to_string()),
+        )
+        .unwrap();
+        let msg = SubMsg::new(CosmosMsg::Bank(BankMsg::Send {
+            to_address: "address".to_string(),
+            amount: vec![coin(100, "uusd")],
+        }));
+        assert_eq!(
+            Response::new()
+                .add_submessage(msg)
+                .add_attribute("action", "withdraw")
+                .add_attribute("recipient", "Addr(\"address\")"),
+            res
+        );
+    }
+
+    #[test]
+    fn test_execute_withdraw_cw20() {
+        let mut deps = mock_dependencies_custom(&[]);
+        let operator = "operator";
+        CONTRACT_OWNER
+            .save(deps.as_mut().storage, &Addr::unchecked("owner"))
+            .unwrap();
+        OPERATORS
+            .save(deps.as_mut().storage, operator, &true)
+            .unwrap();
+        let info = mock_info(operator, &[]);
+        WITHDRAWABLE_TOKENS
+            .save(
+                deps.as_mut().storage,
+                MOCK_CW20_CONTRACT,
+                &AssetInfo::Token {
+                    contract_addr: MOCK_CW20_CONTRACT.into(),
+                },
+            )
+            .unwrap();
+        let res = execute_withdraw(
+            deps.as_ref(),
+            mock_env(),
+            info,
+            Recipient::Addr("address".to_string()),
+        )
+        .unwrap();
+        let msg = SubMsg::new(WasmMsg::Execute {
+            contract_addr: MOCK_CW20_CONTRACT.into(),
+            msg: to_binary(&Cw20ExecuteMsg::Transfer {
+                recipient: "address".to_string(),
+                amount: 10u128.into(),
+            })
+            .unwrap(),
+            funds: vec![],
+        });
+        assert_eq!(
+            Response::new()
+                .add_submessage(msg)
+                .add_attribute("action", "withdraw")
+                .add_attribute("recipient", "Addr(\"address\")"),
+            res
+        );
+    }
 }

--- a/packages/andromeda_protocol/src/withdraw.rs
+++ b/packages/andromeda_protocol/src/withdraw.rs
@@ -28,7 +28,8 @@ pub fn remove_withdrawable_token(
     storage: &mut dyn Storage,
     name: &str,
 ) -> Result<(), ContractError> {
-    Ok(WITHDRAWABLE_TOKENS.remove(storage, name))
+    WITHDRAWABLE_TOKENS.remove(storage, name);
+    Ok(())
 }
 
 /// Withdraw all tokens in WITHDRAWABLE_TOKENS with non-zero balance to the given recipient.

--- a/packages/andromeda_protocol/src/withdraw.rs
+++ b/packages/andromeda_protocol/src/withdraw.rs
@@ -12,9 +12,9 @@ pub const WITHDRAWABLE_TOKENS: Map<&str, AssetInfo> = Map::new("withdrawable_tok
 pub fn add_token(
     storage: &mut dyn Storage,
     name: &str,
-    asset_info: AssetInfo,
+    asset_info: &AssetInfo,
 ) -> Result<(), ContractError> {
-    Ok(WITHDRAWABLE_TOKENS.save(storage, name, &asset_info)?)
+    Ok(WITHDRAWABLE_TOKENS.save(storage, name, asset_info)?)
 }
 
 pub fn remove_token(storage: &mut dyn Storage, name: &str) -> Result<(), ContractError> {


### PR DESCRIPTION
# Motivation
There was a problem where we were unable to withdraw any  funds from the mirror wrapper contract as all withdrawn funds from the actual mirror contract were locked inside the wrapper. To fix this I decided to create a general `withdraw.rs` in the `andromeda_protocol` package which can now be added to any ADO, here is how it works.

 # Implementation

If an ADO wants to be able to withdraw a given cw20 or native token, it can add it as a withdraw-able token with `fn add_withdrawable_token(Storage, &str, &AssetInfo)`. Similarly it can call `fn remove_withdrawable_token(Storage, &str)` to remove a token it no longer wants to be able to withdraw. These tokens are stored in `WITHDRAWABLE_TOKENS: Map<&str, AssetInfo>`. 

To actually withdraw, the ADO needs to implement the `AndromedaMsg::Withdraw { recipient }` message and point it to the `fn execute_withdraw(Deps, Env, Info, Recipient)` function in `withdraw.rs`. This function iterates over each entry stored in `WITHDRAWABLE_TOKENS` and queries the balance of each one. All tokens with a non-empty balance are then withdrawn to the given `recipient`. 

Not only does this allow us to withdraw funds to a user, it also allows us to withdraw to another ADO thanks to the use of `Recipient`. This means we can send CW20 tokens between ADOS and trigger behaviour really easily!

For the mirror contract in particular, there are a few places where we need to store tokens to withdraw. These are:
1. [OpenPosition](https://docs.mirror.finance/contracts/mint#openposition): This call opens a new position by specifying the `collateral` and the `mAsset` the user wants to mint. If it is a short position, the `mAsset` is automatically sold for `uusd` and otherwise the `mAsset` is sent back to the user. Therefore, in the case of a short position, we add the `collateral` and `uusd` as withdraw-able tokens and in the case of a long position we add the `collateral` and `mAsset` as withdraw-able tokens.

2. [OpenPosition (Cw20 Hook)](https://docs.mirror.finance/contracts/mint#openposition-1): Same as above except the collateral is a cw20 token instead of a native token.

3. [Unbond](https://docs.mirror.finance/contracts/staking#unbond) This call unbonds staked LP tokens, so we add the address of the LP token as a withdraw-able token. 

4. [UnlockPositionFunds](https://docs.mirror.finance/contracts/lock#unlockpositionfunds) This call unlocks `uusd` from a short position, so `uusd` is added as a withdraw-able token.

5. `MIR` Token: There are numerous calls which withdraw `MIR`  so for simplicity I added `MIR` as a withdraw-able token in `instantiate`. 

# Testing

## Unit/Integration tests
Unit tests for withdraw functionality were added to `withdraw.rs` and some existing tests for the mirror ADO were extended to also test that `WITHDRAWABLE_TOKENS` was being correctly populated. 

## On-chain tests 
No on-chain tests were conducted for this change yet.

# Future work
I believe the Anchor ADO would benefit from using this withdraw functionality but it needs to be slightly reworked to implement it properly. 

