### PR TITLE
Add OnExecute Hook to AddressList contract 

### DIFF
--- a/contracts/andromeda_addresslist/src/contract.rs
+++ b/contracts/andromeda_addresslist/src/contract.rs
@@ -98,7 +98,7 @@ fn handle_andr_hook(deps: Deps, msg: AndromedaHook) -> Result<Response, Contract
                 Ok(Response::default())
             }
         }
-        _ => panic!(),
+        _ => Err(ContractError::UnsupportedOperation {}),
     }
 }
 

--- a/contracts/andromeda_addresslist/src/contract.rs
+++ b/contracts/andromeda_addresslist/src/contract.rs
@@ -275,7 +275,7 @@ mod tests {
 
         let address = "blacklistee";
 
-        // Mark it as a whitelist.
+        // Mark it as a blacklist.
         IS_INCLUSIVE.save(deps.as_mut().storage, &false).unwrap();
         OPERATORS
             .save(deps.as_mut().storage, operator, &true)

--- a/contracts/andromeda_addresslist/src/contract.rs
+++ b/contracts/andromeda_addresslist/src/contract.rs
@@ -1,9 +1,9 @@
 use andromeda_protocol::{
     address_list::{
         add_address, includes_address, remove_address, ExecuteMsg, IncludesAddressResponse,
-        InstantiateMsg, QueryMsg,
+        InstantiateMsg, QueryMsg, IS_INCLUSIVE,
     },
-    communication::encode_binary,
+    communication::{encode_binary, hooks::AndromedaHook},
     error::ContractError,
     operators::{execute_update_operators, initialize_operators, is_operator, query_is_operator},
     ownership::{execute_update_owner, query_contract_owner, CONTRACT_OWNER},
@@ -19,6 +19,7 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
     initialize_operators(deps.storage, msg.operators)?;
+    IS_INCLUSIVE.save(deps.storage, &msg.is_inclusive)?;
     CONTRACT_OWNER.save(deps.storage, &info.sender)?;
     Ok(Response::default().add_attributes(vec![
         attr("action", "instantiate"),
@@ -82,6 +83,22 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
         QueryMsg::IncludesAddress { address } => encode_binary(&query_address(deps, &address)?),
         QueryMsg::ContractOwner {} => encode_binary(&query_contract_owner(deps)?),
         QueryMsg::IsOperator { address } => encode_binary(&query_is_operator(deps, &address)?),
+        QueryMsg::AndrHook(msg) => encode_binary(&handle_andr_hook(deps, msg)?),
+    }
+}
+
+fn handle_andr_hook(deps: Deps, msg: AndromedaHook) -> Result<Response, ContractError> {
+    match msg {
+        AndromedaHook::OnExecute { sender, .. } => {
+            let included = includes_address(deps.storage, &sender)?;
+            let is_inclusive = IS_INCLUSIVE.load(deps.storage)?;
+            if (is_inclusive && !included) || (!is_inclusive && included) {
+                Err(ContractError::InvalidAddress {})
+            } else {
+                Ok(Response::default())
+            }
+        }
+        _ => panic!(),
     }
 }
 
@@ -96,6 +113,7 @@ mod tests {
     use super::*;
     use andromeda_protocol::address_list::ADDRESS_LIST;
     use andromeda_protocol::operators::OPERATORS;
+    use cosmwasm_std::from_binary;
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
 
     #[test]
@@ -105,6 +123,7 @@ mod tests {
         let info = mock_info("creator", &[]);
         let msg = InstantiateMsg {
             operators: vec!["11".to_string(), "22".to_string()],
+            is_inclusive: true,
         };
         let res = instantiate(deps.as_mut(), env, info, msg).unwrap();
         assert_eq!(0, res.messages.len());
@@ -203,5 +222,87 @@ mod tests {
         let unauth_info = mock_info("anyone", &[]);
         let res = execute(deps.as_mut(), env, unauth_info, msg).unwrap_err();
         assert_eq!(ContractError::Unauthorized {}, res);
+    }
+
+    #[test]
+    fn test_execute_hook_whitelist() {
+        let mut deps = mock_dependencies(&[]);
+        let env = mock_env();
+
+        let operator = "creator";
+        let info = mock_info(operator, &[]);
+
+        let address = "whitelistee";
+
+        // Mark it as a whitelist.
+        IS_INCLUSIVE.save(deps.as_mut().storage, &true).unwrap();
+        OPERATORS
+            .save(deps.as_mut().storage, operator, &true)
+            .unwrap();
+        CONTRACT_OWNER
+            .save(deps.as_mut().storage, &info.sender)
+            .unwrap();
+
+        let msg = ExecuteMsg::AddAddress {
+            address: address.to_string(),
+        };
+        let _res = execute(deps.as_mut(), env.clone(), info, msg.clone()).unwrap();
+
+        let msg = QueryMsg::AndrHook(AndromedaHook::OnExecute {
+            sender: address.to_string(),
+            msg: encode_binary(&"".to_string()).unwrap(),
+        });
+
+        let res: Response = from_binary(&query(deps.as_ref(), mock_env(), msg).unwrap()).unwrap();
+        assert_eq!(Response::default(), res);
+
+        let msg = QueryMsg::AndrHook(AndromedaHook::OnExecute {
+            sender: "random".to_string(),
+            msg: encode_binary(&"".to_string()).unwrap(),
+        });
+
+        let res_err: ContractError = query(deps.as_ref(), mock_env(), msg).unwrap_err();
+        assert_eq!(ContractError::InvalidAddress {}, res_err);
+    }
+
+    #[test]
+    fn test_execute_hook_blacklist() {
+        let mut deps = mock_dependencies(&[]);
+        let env = mock_env();
+
+        let operator = "creator";
+        let info = mock_info(operator, &[]);
+
+        let address = "blacklistee";
+
+        // Mark it as a whitelist.
+        IS_INCLUSIVE.save(deps.as_mut().storage, &false).unwrap();
+        OPERATORS
+            .save(deps.as_mut().storage, operator, &true)
+            .unwrap();
+        CONTRACT_OWNER
+            .save(deps.as_mut().storage, &info.sender)
+            .unwrap();
+
+        let msg = ExecuteMsg::AddAddress {
+            address: address.to_string(),
+        };
+        let _res = execute(deps.as_mut(), env.clone(), info, msg.clone()).unwrap();
+
+        let msg = QueryMsg::AndrHook(AndromedaHook::OnExecute {
+            sender: "random".to_string(),
+            msg: encode_binary(&"".to_string()).unwrap(),
+        });
+
+        let res: Response = from_binary(&query(deps.as_ref(), mock_env(), msg).unwrap()).unwrap();
+        assert_eq!(Response::default(), res);
+
+        let msg = QueryMsg::AndrHook(AndromedaHook::OnExecute {
+            sender: address.to_string(),
+            msg: encode_binary(&"".to_string()).unwrap(),
+        });
+
+        let res_err: ContractError = query(deps.as_ref(), mock_env(), msg).unwrap_err();
+        assert_eq!(ContractError::InvalidAddress {}, res_err);
     }
 }

--- a/contracts/andromeda_addresslist/src/contract.rs
+++ b/contracts/andromeda_addresslist/src/contract.rs
@@ -246,7 +246,7 @@ mod tests {
         let msg = ExecuteMsg::AddAddress {
             address: address.to_string(),
         };
-        let _res = execute(deps.as_mut(), env.clone(), info, msg.clone()).unwrap();
+        let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
         let msg = QueryMsg::AndrHook(AndromedaHook::OnExecute {
             sender: address.to_string(),
@@ -287,7 +287,7 @@ mod tests {
         let msg = ExecuteMsg::AddAddress {
             address: address.to_string(),
         };
-        let _res = execute(deps.as_mut(), env.clone(), info, msg.clone()).unwrap();
+        let _res = execute(deps.as_mut(), env, info, msg).unwrap();
 
         let msg = QueryMsg::AndrHook(AndromedaHook::OnExecute {
             sender: "random".to_string(),

--- a/contracts/andromeda_addresslist/src/contract.rs
+++ b/contracts/andromeda_addresslist/src/contract.rs
@@ -90,9 +90,9 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
 fn handle_andr_hook(deps: Deps, msg: AndromedaHook) -> Result<Response, ContractError> {
     match msg {
         AndromedaHook::OnExecute { sender, .. } => {
-            let included = includes_address(deps.storage, &sender)?;
+            let is_included = includes_address(deps.storage, &sender)?;
             let is_inclusive = IS_INCLUSIVE.load(deps.storage)?;
-            if (is_inclusive && !included) || (!is_inclusive && included) {
+            if is_included != is_inclusive {
                 Err(ContractError::InvalidAddress {})
             } else {
                 Ok(Response::default())

--- a/contracts/andromeda_cw20/src/contract.rs
+++ b/contracts/andromeda_cw20/src/contract.rs
@@ -120,7 +120,7 @@ fn execute_transfer(
             amount,
         }),
         to_binary(&ExecuteMsg::Transfer {
-            amount: amount.clone(),
+            amount,
             recipient: recipient.clone(),
         })?,
     )?;

--- a/contracts/andromeda_splitter/src/testing/tests.rs
+++ b/contracts/andromeda_splitter/src/testing/tests.rs
@@ -43,6 +43,7 @@ fn test_instantiate() {
                 label: String::from("Address list instantiation"),
                 msg: to_binary(&AddressListInstantiateMsg {
                     operators: vec!["creator".to_string()],
+                    is_inclusive: true,
                 })
                 .unwrap(),
             }),

--- a/contracts/andromeda_token/src/testing/tests.rs
+++ b/contracts/andromeda_token/src/testing/tests.rs
@@ -74,6 +74,7 @@ fn test_token_modules() {
                 label: String::from("Address list instantiation"),
                 msg: to_binary(&AddressListInstantiateMsg {
                     operators: vec![sender.to_string()],
+                    is_inclusive: true,
                 })
                 .unwrap(),
             }),

--- a/packages/andromeda_protocol/src/modules/address_list.rs
+++ b/packages/andromeda_protocol/src/modules/address_list.rs
@@ -132,6 +132,7 @@ impl MessageHooks for AddressListModule {
                 label: String::from("Address list instantiation"),
                 msg: to_binary(&AddressListInstantiateMsg {
                     operators: self.operators.clone().unwrap(),
+                    is_inclusive: true,
                 })?,
             };
 


### PR DESCRIPTION
# Motivation
We are moving to a new modules architecture which delegates computation to other contracts instead of keeping it all in one contract. This change implements the new `AndromedaHook` message type to facilitate this. 

# Implementation
I added `is_inclusive: bool` to the `InstantiateMsg` of the AddressList contract as it was previously handled by the module. This field represents if it is a whitelist (`true`) or a blacklist (`false`). The `OnExecute` hook simply checks if the attached sender should have access given the configuration and returns an error if they aren't. 

Where `InstantiateMsg` was used already I added a temporary line `is_inclusive: true` so it compiles, but we will be changing how this works in the near future. 

# Testing

## Unit/Integration tests
Unit tests for the hook were added to the AddressList contract.

## On-chain tests 
No on-chain tests were conducted for this change yet.

# Future work
Integrate the hooks to the other module contracts. 

