### PR TITLE
CU-1ware1z | Add module validation

### DIFF
--- a/contracts/andromeda_cw20/src/contract.rs
+++ b/contracts/andromeda_cw20/src/contract.rs
@@ -8,7 +8,10 @@ use cosmwasm_std::{
 use andromeda_protocol::{
     communication::{
         hooks::AndromedaHook,
-        modules::{module_hook, on_funds_transfer, register_module, MODULE_ADDR, MODULE_INFO},
+        modules::{
+            module_hook, on_funds_transfer, register_module, validate_modules, ADOType,
+            MODULE_ADDR, MODULE_INFO,
+        },
     },
     cw20::{ExecuteMsg, InstantiateMsg, QueryMsg},
     error::ContractError,
@@ -33,6 +36,7 @@ pub fn instantiate(
 ) -> Result<Response, ContractError> {
     let mut resp = Response::default();
     if let Some(modules) = msg.modules.clone() {
+        validate_modules(&modules, ADOType::CW20)?;
         for module in modules {
             let idx = register_module(deps.storage, deps.api, &module)?;
             if let Some(inst_msg) = module.generate_instantiate_msg(deps.querier, idx)? {

--- a/packages/andromeda_protocol/src/communication/modules.rs
+++ b/packages/andromeda_protocol/src/communication/modules.rs
@@ -77,7 +77,6 @@ pub struct ModuleInfoWithAddress {
 
 /// The type of ADO that is using these modules.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
 pub enum ADOType {
     CW721,
     CW20,
@@ -131,6 +130,8 @@ impl Module {
         }
     }
 
+    /// Validates `self` by checking that it is unique, does not conflict with any other module,
+    /// and does not conflict with the creating ADO.
     pub fn validate(&self, modules: &[Module], ado_type: &ADOType) -> Result<(), ContractError> {
         require(self.is_unique(modules), ContractError::ModuleNotUnique {})?;
 

--- a/packages/andromeda_protocol/src/communication/modules.rs
+++ b/packages/andromeda_protocol/src/communication/modules.rs
@@ -40,8 +40,8 @@ pub enum ModuleType {
 impl From<ModuleType> for String {
     fn from(module_type: ModuleType) -> Self {
         match module_type {
-            ModuleType::Whitelist => String::from("whitelist"),
-            ModuleType::Blacklist => String::from("blacklist"),
+            ModuleType::Whitelist => String::from("address_list"),
+            ModuleType::Blacklist => String::from("address_list"),
             ModuleType::Rates => String::from("rates"),
             ModuleType::Auction => String::from("auction"),
             ModuleType::Other => String::from("other"),

--- a/packages/andromeda_protocol/src/error.rs
+++ b/packages/andromeda_protocol/src/error.rs
@@ -140,8 +140,12 @@ pub enum ContractError {
     // END CW20 ERRORS
     #[error("Invalid Module")]
     InvalidModule { msg: Option<String> },
+
     #[error("UnsupportedOperation")]
     UnsupportedOperation {},
+
+    #[error("IncompatibleModules")]
+    IncompatibleModules { msg: String },
 }
 
 impl From<Cw20ContractError> for ContractError {

--- a/packages/andromeda_protocol/src/modules/common.rs
+++ b/packages/andromeda_protocol/src/modules/common.rs
@@ -70,7 +70,7 @@ pub fn is_unique<M: Module>(module: &M, all_modules: &[ModuleDefinition]) -> boo
 /// ## Arguments
 /// * `coins` - The vector of `Coin` structs from which to deduct the given funds
 /// * `funds` - The amount to deduct
-pub fn deduct_funds(coins: &mut Vec<Coin>, funds: &Coin) -> Result<bool, ContractError> {
+pub fn deduct_funds(coins: &mut [Coin], funds: &Coin) -> Result<bool, ContractError> {
     let coin_amount = coins.iter_mut().find(|c| c.denom.eq(&funds.denom));
 
     match coin_amount {
@@ -110,7 +110,7 @@ pub fn add_payment(payments: &mut Vec<BankMsg>, to: String, amount: Coin) {
 ///
 /// Errors if there is no payment from which to deduct the funds
 pub fn deduct_payment(
-    payments: &mut Vec<BankMsg>,
+    payments: &mut [BankMsg],
     to: String,
     amount: Coin,
 ) -> Result<bool, ContractError> {

--- a/packages/andromeda_protocol/src/modules/hooks.rs
+++ b/packages/andromeda_protocol/src/modules/hooks.rs
@@ -197,6 +197,7 @@ pub trait MessageHooks {
         Ok(HookResponse::default())
     }
     /// Called whenever an agreed transfer is taking place
+    #[allow(clippy::ptr_arg)]
     fn on_agreed_transfer(
         &self,
         _deps: &DepsMut,


### PR DESCRIPTION
# Motivation
As with the previous module implementation, we want to be able to validate modules using this new approach.

# Implementation
I added a method `fn validate(&self, modules: &[Module], ado_type: &ADOType)` to the `Module` struct, which validates the following:

1. The given module is unique.
2. If the ADO which is using these modules is the CW20 ADO, an Auction module is invalid.

I also added a method `fn validate_modules(modules: &[Module], ado_type: ADOType)` which validates each module in the given vector. This is the entry point that is used by the creating ADO to validate its modules. 

# Testing

## Unit/Integration tests
Added unit tests for the validating of each Module. An integration test for them will be added once we finalize the design of this new system.

## On-chain tests 
No on-chain tests were conducted for this change yet.

# Future work
This PR is part of a larger effort to improve our module architecture so subsequent PRs will build on top of this. 

