### PR TITLE
CU-1ware2q | Allow registering, altering, and deregistering modules

### DIFF
--- a/packages/andromeda_protocol/src/communication/modules.rs
+++ b/packages/andromeda_protocol/src/communication/modules.rs
@@ -1,22 +1,23 @@
 use std::convert::TryInto;
 
 use cosmwasm_std::{
-    to_binary, wasm_instantiate, Addr, Api, Binary, CosmosMsg, Event, Order, QuerierWrapper,
-    QueryRequest, ReplyOn, StdError, Storage, SubMsg, WasmQuery,
+    to_binary, wasm_instantiate, Addr, Api, Binary, CosmosMsg, DepsMut, Event, MessageInfo, Order,
+    QuerierWrapper, QueryRequest, ReplyOn, Response, StdError, Storage, SubMsg, Uint64, WasmQuery,
 };
 use cw_storage_plus::{Bound, Item, Map};
 use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
-    communication::query_get, error::ContractError, factory::CodeIdResponse, rates::Funds, require,
+    communication::query_get, error::ContractError, factory::CodeIdResponse,
+    operators::is_operator, ownership::is_contract_owner, rates::Funds, require,
 };
 
 use super::hooks::{AndromedaHook, OnFundsTransferResponse};
 
 pub const FACTORY_ADDRESS: &str = "terra1...";
-pub const MODULE_INFO: Map<String, Module> = Map::new("andr_modules");
-pub const MODULE_ADDR: Map<String, Addr> = Map::new("andr_module_addresses");
+pub const MODULE_INFO: Map<&str, Module> = Map::new("andr_modules");
+pub const MODULE_ADDR: Map<&str, Addr> = Map::new("andr_module_addresses");
 pub const MODULE_IDX: Item<u64> = Item::new("andr_module_idx");
 
 /// An enum describing the different available modules for any Andromeda Token contract
@@ -99,28 +100,27 @@ impl Module {
         querier: QuerierWrapper,
         module_id: u64,
     ) -> Result<Option<SubMsg>, ContractError> {
-        match self.instantiate.clone() {
-            InstantiateType::New(msg) => {
-                match self.get_code_id(querier)? {
-                    None => Err(ContractError::InvalidModule {
-                        msg: Some(String::from(
-                            "Module type provided does not have a valid Code Id",
-                        )),
-                    }),
-                    Some(code_id) => Ok(Some(SubMsg {
-                        id: module_id, //TODO: ADD ID,
-                        reply_on: ReplyOn::Always,
-                        msg: CosmosMsg::Wasm(wasm_instantiate(
-                            code_id,
-                            &msg,
-                            vec![],
-                            format!("Instantiate: {}", String::from(self.module_type.clone())),
-                        )?),
-                        gas_limit: None,
-                    })),
-                }
+        if let InstantiateType::New(msg) = &self.instantiate {
+            match self.get_code_id(querier)? {
+                None => Err(ContractError::InvalidModule {
+                    msg: Some(String::from(
+                        "Module type provided does not have a valid Code Id",
+                    )),
+                }),
+                Some(code_id) => Ok(Some(SubMsg {
+                    id: module_id, //TODO: ADD ID,
+                    reply_on: ReplyOn::Always,
+                    msg: CosmosMsg::Wasm(wasm_instantiate(
+                        code_id,
+                        msg,
+                        vec![],
+                        format!("Instantiate: {}", String::from(self.module_type.clone())),
+                    )?),
+                    gas_limit: None,
+                })),
             }
-            _ => Ok(None),
+        } else {
+            Ok(None)
         }
     }
 
@@ -165,7 +165,7 @@ fn contains_module(modules: &[Module], module_type: ModuleType) -> bool {
 /// If the module has provided an address as its form of instantiation this address is recorded
 /// Each module is assigned a u64 index so as it can be unregistered/altered
 /// The assigned u64 index is used as the message id for use in the `reply` entry point of the contract
-pub fn register_module(
+fn register_module(
     storage: &mut dyn Storage,
     api: &dyn Api,
     module: &Module,
@@ -174,13 +174,111 @@ pub fn register_module(
         Ok(index) => index,
         Err(..) => 1u64,
     };
-    MODULE_INFO.save(storage, idx.to_string(), module)?;
+    let idx_str = idx.to_string();
+    MODULE_INFO.save(storage, &idx_str, module)?;
     MODULE_IDX.save(storage, &(idx + 1))?;
     if let InstantiateType::Address(addr) = module.instantiate.clone() {
-        MODULE_ADDR.save(storage, idx.to_string(), &api.addr_validate(&addr)?)?;
+        MODULE_ADDR.save(storage, &idx_str, &api.addr_validate(&addr)?)?;
     }
 
     Ok(idx)
+}
+
+/// Deregisters a module.
+fn deregister_module(storage: &mut dyn Storage, idx: Uint64) -> Result<(), ContractError> {
+    let idx_str = idx.to_string();
+    MODULE_INFO.remove(storage, &idx_str);
+    MODULE_ADDR.remove(storage, &idx_str);
+
+    Ok(())
+}
+
+/// Alters a module
+/// If the module has provided an address as its form of instantiation this address is recorded
+/// Each module is assigned a u64 index so as it can be unregistered/altered
+/// The assigned u64 index is used as the message id for use in the `reply` entry point of the contract
+fn alter_module(
+    storage: &mut dyn Storage,
+    api: &dyn Api,
+    idx: Uint64,
+    module: &Module,
+) -> Result<(), ContractError> {
+    let idx_str = idx.to_string();
+    if !MODULE_INFO.has(storage, &idx_str) {
+        return Err(ContractError::ModuleDoesNotExist {});
+    }
+    MODULE_INFO.save(storage, &idx_str, module)?;
+    if let InstantiateType::Address(addr) = module.instantiate.clone() {
+        MODULE_ADDR.save(storage, &idx_str, &api.addr_validate(&addr)?)?;
+    }
+    Ok(())
+}
+
+/// A wrapper for `fn register_module`. The parameters are "extracted" from `DepsMut` to be able to
+/// execute this in a loop without cloning.
+pub fn execute_register_module(
+    querier: &QuerierWrapper,
+    storage: &mut dyn Storage,
+    api: &dyn Api,
+    sender: &str,
+    module: &Module,
+    ado_type: ADOType,
+    should_validate: bool,
+) -> Result<Response, ContractError> {
+    require(
+        is_contract_owner(storage, sender)? || is_operator(storage, sender)?,
+        ContractError::Unauthorized {},
+    )?;
+    let mut resp = Response::default();
+    let idx = register_module(storage, api, module)?;
+    if let Some(inst_msg) = module.generate_instantiate_msg(*querier, idx)? {
+        resp = resp.add_submessage(inst_msg);
+    }
+    if should_validate {
+        validate_modules(&load_modules(storage)?, ado_type)?;
+    }
+    Ok(resp.add_attribute("action", "register_module"))
+}
+
+/// A wrapper for `fn alter_module`.
+pub fn execute_alter_module(
+    deps: DepsMut,
+    info: MessageInfo,
+    module_idx: Uint64,
+    module: &Module,
+    ado_type: ADOType,
+) -> Result<Response, ContractError> {
+    let addr = info.sender.as_str();
+    require(
+        is_contract_owner(deps.storage, addr)? || is_operator(deps.storage, addr)?,
+        ContractError::Unauthorized {},
+    )?;
+    let mut resp = Response::default();
+    alter_module(deps.storage, deps.api, module_idx, module)?;
+    if let Some(inst_msg) = module.generate_instantiate_msg(deps.querier, module_idx.u64())? {
+        resp = resp.add_submessage(inst_msg);
+    }
+    validate_modules(&load_modules(deps.storage)?, ado_type)?;
+    Ok(resp
+        .add_attribute("action", "alter_module")
+        .add_attribute("module_idx", module_idx))
+}
+
+/// A wrapper for `fn deregister_module`.
+pub fn execute_deregister_module(
+    deps: DepsMut,
+    info: MessageInfo,
+    module_idx: Uint64,
+) -> Result<Response, ContractError> {
+    let addr = info.sender.as_str();
+    require(
+        is_contract_owner(deps.storage, addr)? || is_operator(deps.storage, addr)?,
+        ContractError::Unauthorized {},
+    )?;
+    deregister_module(deps.storage, module_idx)?;
+    Ok(Response::default()
+        .add_attribute("action", "deregister_module")
+        .add_attribute("module_idx", module_idx))
 }
 
 /// Loads all registered modules in Vector form
@@ -352,6 +450,8 @@ fn query_on_funds_transfer(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ownership::CONTRACT_OWNER;
+    use cosmwasm_std::testing::{mock_dependencies, mock_info};
 
     #[test]
     fn test_validate_addresslist() {
@@ -441,5 +541,217 @@ mod tests {
         module
             .validate(&[module.clone(), other_module], &ADOType::CW721)
             .unwrap();
+    }
+
+    #[test]
+    fn test_execute_register_module_unauthorized() {
+        let mut deps = mock_dependencies(&[]);
+
+        let module = Module {
+            module_type: ModuleType::AddressList,
+            instantiate: InstantiateType::Address("address".to_string()),
+        };
+        let deps_mut = deps.as_mut();
+        CONTRACT_OWNER
+            .save(deps_mut.storage, &Addr::unchecked("owner"))
+            .unwrap();
+
+        let res = execute_register_module(
+            &deps_mut.querier,
+            deps_mut.storage,
+            deps_mut.api,
+            "sender",
+            &module,
+            ADOType::CW20,
+            true,
+        );
+
+        assert_eq!(ContractError::Unauthorized {}, res.unwrap_err());
+    }
+
+    #[test]
+    fn test_execute_register_module_addr() {
+        let mut deps = mock_dependencies(&[]);
+
+        let module = Module {
+            module_type: ModuleType::AddressList,
+            instantiate: InstantiateType::Address("address".to_string()),
+        };
+        let deps_mut = deps.as_mut();
+        CONTRACT_OWNER
+            .save(deps_mut.storage, &Addr::unchecked("owner"))
+            .unwrap();
+
+        let res = execute_register_module(
+            &deps_mut.querier,
+            deps_mut.storage,
+            deps_mut.api,
+            "owner",
+            &module,
+            ADOType::CW20,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(
+            Response::default().add_attribute("action", "register_module"),
+            res
+        );
+    }
+
+    #[test]
+    fn test_execute_register_module_validate() {
+        let mut deps = mock_dependencies(&[]);
+
+        let module = Module {
+            module_type: ModuleType::Auction,
+            instantiate: InstantiateType::Address("address".to_string()),
+        };
+        let deps_mut = deps.as_mut();
+        CONTRACT_OWNER
+            .save(deps_mut.storage, &Addr::unchecked("owner"))
+            .unwrap();
+
+        let res = execute_register_module(
+            &deps_mut.querier,
+            deps_mut.storage,
+            deps_mut.api,
+            "owner",
+            &module,
+            ADOType::CW20,
+            true,
+        );
+
+        assert_eq!(
+            ContractError::IncompatibleModules {
+                msg: "An Auction module cannot be used for a CW20 ADO".to_string()
+            },
+            res.unwrap_err(),
+        );
+
+        let res = execute_register_module(
+            &deps_mut.querier,
+            deps_mut.storage,
+            deps_mut.api,
+            "owner",
+            &module,
+            ADOType::CW20,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            Response::default().add_attribute("action", "register_module"),
+            res
+        );
+    }
+
+    #[test]
+    fn test_execute_alter_module_unauthorized() {
+        let mut deps = mock_dependencies(&[]);
+        let info = mock_info("sender", &[]);
+        let module = Module {
+            module_type: ModuleType::AddressList,
+            instantiate: InstantiateType::Address("address".to_string()),
+        };
+        CONTRACT_OWNER
+            .save(deps.as_mut().storage, &Addr::unchecked("owner"))
+            .unwrap();
+
+        let res = execute_alter_module(deps.as_mut(), info, 1u64.into(), &module, ADOType::CW20);
+
+        assert_eq!(ContractError::Unauthorized {}, res.unwrap_err());
+    }
+
+    #[test]
+    fn test_execute_alter_module_addr() {
+        let mut deps = mock_dependencies(&[]);
+        let info = mock_info("owner", &[]);
+        let module = Module {
+            module_type: ModuleType::AddressList,
+            instantiate: InstantiateType::Address("address".to_string()),
+        };
+        CONTRACT_OWNER
+            .save(deps.as_mut().storage, &Addr::unchecked("owner"))
+            .unwrap();
+
+        let res =
+            execute_alter_module(deps.as_mut(), info, 1u64.into(), &module, ADOType::CW20).unwrap();
+
+        assert_eq!(
+            Response::default()
+                .add_attribute("action", "alter_module")
+                .add_attribute("module_idx", "1"),
+            res
+        );
+    }
+
+    #[test]
+    fn test_execute_alter_module_invalid_module() {
+        let mut deps = mock_dependencies(&[]);
+        let info = mock_info("owner", &[]);
+        let module = Module {
+            module_type: ModuleType::Auction,
+            instantiate: InstantiateType::Address("address".to_string()),
+        };
+        CONTRACT_OWNER
+            .save(deps.as_mut().storage, &Addr::unchecked("owner"))
+            .unwrap();
+
+        let res = execute_alter_module(deps.as_mut(), info, 1u64.into(), &module, ADOType::CW20);
+
+        assert_eq!(
+            ContractError::IncompatibleModules {
+                msg: "An Auction module cannot be used for a CW20 ADO".to_string()
+            },
+            res.unwrap_err(),
+        );
+    }
+
+    #[test]
+    fn test_execute_deregister_module_unauthorized() {
+        let mut deps = mock_dependencies(&[]);
+        let info = mock_info("sender", &[]);
+        CONTRACT_OWNER
+            .save(deps.as_mut().storage, &Addr::unchecked("owner"))
+            .unwrap();
+
+        let res = execute_deregister_module(deps.as_mut(), info, 1u64.into());
+
+        assert_eq!(ContractError::Unauthorized {}, res.unwrap_err());
+    }
+
+    #[test]
+    fn test_execute_deregister_module() {
+        let mut deps = mock_dependencies(&[]);
+        let info = mock_info("owner", &[]);
+        CONTRACT_OWNER
+            .save(deps.as_mut().storage, &Addr::unchecked("owner"))
+            .unwrap();
+
+        let module = Module {
+            module_type: ModuleType::AddressList,
+            instantiate: InstantiateType::Address("address".to_string()),
+        };
+
+        MODULE_INFO
+            .save(deps.as_mut().storage, "1", &module)
+            .unwrap();
+
+        MODULE_ADDR
+            .save(deps.as_mut().storage, "1", &Addr::unchecked("address"))
+            .unwrap();
+
+        let res = execute_deregister_module(deps.as_mut(), info, 1u64.into()).unwrap();
+
+        assert_eq!(
+            Response::default()
+                .add_attribute("action", "deregister_module")
+                .add_attribute("module_idx", "1"),
+            res
+        );
+
+        assert!(!MODULE_ADDR.has(deps.as_mut().storage, "1"));
+        assert!(!MODULE_INFO.has(deps.as_mut().storage, "1"));
     }
 }

--- a/packages/andromeda_protocol/src/communication/modules.rs
+++ b/packages/andromeda_protocol/src/communication/modules.rs
@@ -177,8 +177,8 @@ fn register_module(
     let idx_str = idx.to_string();
     MODULE_INFO.save(storage, &idx_str, module)?;
     MODULE_IDX.save(storage, &(idx + 1))?;
-    if let InstantiateType::Address(addr) = module.instantiate.clone() {
-        MODULE_ADDR.save(storage, &idx_str, &api.addr_validate(&addr)?)?;
+    if let InstantiateType::Address(addr) = &module.instantiate {
+        MODULE_ADDR.save(storage, &idx_str, &api.addr_validate(addr)?)?;
     }
 
     Ok(idx)
@@ -211,8 +211,8 @@ fn alter_module(
         return Err(ContractError::ModuleDoesNotExist {});
     }
     MODULE_INFO.save(storage, &idx_str, module)?;
-    if let InstantiateType::Address(addr) = module.instantiate.clone() {
-        MODULE_ADDR.save(storage, &idx_str, &api.addr_validate(&addr)?)?;
+    if let InstantiateType::Address(addr) = &module.instantiate {
+        MODULE_ADDR.save(storage, &idx_str, &api.addr_validate(addr)?)?;
     }
     Ok(())
 }

--- a/packages/andromeda_protocol/src/cw20.rs
+++ b/packages/andromeda_protocol/src/cw20.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Binary, Uint128};
+use cosmwasm_std::{Binary, Uint128, Uint64};
 use cw0::Expiration;
 use cw20::{Cw20Coin, Logo, MinterResponse};
 use cw20_base::msg::{
@@ -38,9 +38,14 @@ impl From<InstantiateMsg> for Cw20InstantiateMsg {
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
     /// Transfer is a base message to move tokens to another account without triggering actions
-    Transfer { recipient: String, amount: Uint128 },
+    Transfer {
+        recipient: String,
+        amount: Uint128,
+    },
     /// Burn is a base message to destroy tokens forever
-    Burn { amount: Uint128 },
+    Burn {
+        amount: Uint128,
+    },
     /// Send is a base message to transfer tokens to a contract and trigger an action
     /// on the receiving contract.
     Send {
@@ -80,10 +85,16 @@ pub enum ExecuteMsg {
         msg: Binary,
     },
     /// Only with "approval" extension. Destroys tokens forever
-    BurnFrom { owner: String, amount: Uint128 },
+    BurnFrom {
+        owner: String,
+        amount: Uint128,
+    },
     /// Only with the "mintable" extension. If authorized, creates amount new tokens
     /// and adds to the recipient balance.
-    Mint { recipient: String, amount: Uint128 },
+    Mint {
+        recipient: String,
+        amount: Uint128,
+    },
     /// Only with the "marketing" extension. If authorized, updates marketing metadata.
     /// Setting None/null for any of these will leave it unchanged.
     /// Setting Some("") will clear this field on the contract storage
@@ -97,6 +108,17 @@ pub enum ExecuteMsg {
     },
     /// If set as the "marketing" role on the contract, upload a new URL, SVG, or PNG for the token
     UploadLogo(Logo),
+
+    RegisterModule {
+        module: Module,
+    },
+    DeregisterModule {
+        module_idx: Uint64,
+    },
+    AlterModule {
+        module_idx: Uint64,
+        module: Module,
+    },
 }
 
 impl From<ExecuteMsg> for Cw20ExecuteMsg {
@@ -165,6 +187,7 @@ impl From<ExecuteMsg> for Cw20ExecuteMsg {
                 marketing,
             },
             ExecuteMsg::UploadLogo(logo) => Cw20ExecuteMsg::UploadLogo(logo),
+            _ => panic!("Unsupported message"),
         }
     }
 }

--- a/packages/andromeda_protocol/src/error.rs
+++ b/packages/andromeda_protocol/src/error.rs
@@ -146,6 +146,9 @@ pub enum ContractError {
 
     #[error("IncompatibleModules")]
     IncompatibleModules { msg: String },
+
+    #[error("ModuleDoesNotExist")]
+    ModuleDoesNotExist {},
 }
 
 impl From<Cw20ContractError> for ContractError {


### PR DESCRIPTION
# Motivation
Currently it is only possible to register modules on instantiation which doesn't provide much in the way of flexibility. 

# Implementation
I added two new functions in `modules.rs` that handle altering and deregistering modules similar to the existing `fn register_modules`. I then created three wrappers `fn execute_register_module(...)`, `fn execute_alter_module(...)`, and `fn execute_deregister_module(...)`. I refactored the `instantiate` function for the CW20 ADO to use `execute_register_module` instead of the `register_module` function for consistency. 

All three of these operations can be done with the newly added messages `RegisterModule { module }`, `AlterModule { module_idx, module }` and `DeregisterModule { module_idx }`.

I also did some small refactors to improve efficiency by replacing `String` for the key of the `MODULE_INFO` and `MODULE_ADDR` with `&str` and eliminating a few clones by borrowing instead.

# Testing

## Unit/Integration tests
I added unit tests for each of the newly added functions but did not test the case of a module with an instantiate message as we don't have the factory address properly configured yet. 

## On-chain tests
No on chain tests yet. 

# Future work
Once we set up the fetch contract and get it configured in this contract we can add tests for the case of instantiating a module that doesn't yet exist onchain.