### PR TITLE
Assortment of fixes for CW20 ADO from onchain-testing

### DIFF
--- a/contracts/andromeda_cw20/src/contract.rs
+++ b/contracts/andromeda_cw20/src/contract.rs
@@ -160,22 +160,15 @@ fn execute_transfer(
             CosmosMsg::Wasm(wasm_msg) => match wasm_msg {
                 WasmMsg::Execute { msg: exec_msg, .. } => {
                     // If binary deserializes to a Cw20ExecuteMsg check the message type
-                    if let Ok(transfer_msg) = from_binary::<Cw20ExecuteMsg>(&exec_msg) {
-                        match transfer_msg {
-                            // If the message is a transfer message then transfer the tokens from the current message sender to the recipient
-                            Cw20ExecuteMsg::Transfer { recipient, amount } => {
-                                transfer_tokens(
-                                    deps.storage,
-                                    sender.clone(),
-                                    deps.api.addr_validate(&recipient)?,
-                                    amount,
-                                )?;
-                            }
-                            // Otherwise add to messages to be sent in response
-                            _ => {
-                                resp = resp.add_submessage(msg);
-                            }
-                        }
+                    if let Ok(Cw20ExecuteMsg::Transfer { recipient, amount }) =
+                        from_binary::<Cw20ExecuteMsg>(&exec_msg)
+                    {
+                        transfer_tokens(
+                            deps.storage,
+                            sender.clone(),
+                            deps.api.addr_validate(&recipient)?,
+                            amount,
+                        )?;
                     } else {
                         // Need this so receipt messages will be added too.
                         resp = resp.add_submessage(msg);

--- a/contracts/andromeda_cw20/src/contract.rs
+++ b/contracts/andromeda_cw20/src/contract.rs
@@ -135,7 +135,7 @@ fn execute_transfer(
 ) -> Result<Response, ContractError> {
     let mut resp = Response::new();
     let sender = info.sender.clone();
-    let (payments, events, remainder) = on_funds_transfer(
+    let (msgs, events, remainder) = on_funds_transfer(
         deps.storage,
         deps.querier,
         info.sender.to_string(),
@@ -154,7 +154,7 @@ fn execute_transfer(
     };
 
     // Filter through payment messages to extract cw20 transfer messages to avoid looping
-    for msg in payments {
+    for msg in msgs {
         match msg.msg.clone() {
             // Transfer messages are CosmosMsg::Wasm type
             CosmosMsg::Wasm(wasm_msg) => match wasm_msg {
@@ -176,6 +176,9 @@ fn execute_transfer(
                                 resp = resp.add_submessage(msg);
                             }
                         }
+                    } else {
+                        // Need this so receipt messages will be added too.
+                        resp = resp.add_submessage(msg);
                     }
                 }
                 // Otherwise add to messages to be sent in response

--- a/contracts/andromeda_cw20/src/contract.rs
+++ b/contracts/andromeda_cw20/src/contract.rs
@@ -41,7 +41,7 @@ pub fn instantiate(
     if let Some(modules) = msg.modules.clone() {
         validate_modules(&modules, ADOType::CW20)?;
         for module in modules {
-            resp = execute_register_module(
+            let response = execute_register_module(
                 &deps.querier,
                 deps.storage,
                 deps.api,
@@ -50,6 +50,7 @@ pub fn instantiate(
                 ADOType::CW20,
                 false,
             )?;
+            resp = resp.add_submessages(response.messages);
         }
     }
     let cw20_resp = cw20_instantiate(deps, env, info, msg.into())?;

--- a/contracts/andromeda_rates/src/contract.rs
+++ b/contracts/andromeda_rates/src/contract.rs
@@ -82,7 +82,7 @@ fn execute_update_rates(
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
     match msg {
         QueryMsg::AndrQuery(msg) => handle_andromeda_query(deps, msg),
-        QueryMsg::Hook(msg) => handle_andromeda_hook(deps, msg),
+        QueryMsg::AndrHook(msg) => handle_andromeda_hook(deps, msg),
         QueryMsg::Payments {} => encode_binary(&query_payments(deps)?),
     }
 }

--- a/packages/andromeda_protocol/src/communication/mod.rs
+++ b/packages/andromeda_protocol/src/communication/mod.rs
@@ -22,6 +22,7 @@ pub struct ADORecipient {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum Recipient {
     Addr(String),
     ADO(ADORecipient),
@@ -132,8 +133,15 @@ pub enum ExecuteMsg {
 /// Helper enum for serialization
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    AndrQuery(AndromedaQuery),
+}
+
+/// Helper enum for serialization
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum HookMsg {
-    Hook(AndromedaHook),
+    AndrHook(AndromedaHook),
 }
 
 pub fn parse_struct<T>(val: &Binary) -> Result<T, ContractError>
@@ -175,7 +183,7 @@ pub fn query_get<T>(
 where
     T: DeserializeOwned,
 {
-    let query_msg = AndromedaQuery::Get(data);
+    let query_msg = QueryMsg::AndrQuery(AndromedaQuery::Get(data));
     let resp: T = querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
         contract_addr: address,
         msg: to_binary(&query_msg)?,

--- a/packages/andromeda_protocol/src/communication/modules.rs
+++ b/packages/andromeda_protocol/src/communication/modules.rs
@@ -20,7 +20,7 @@ use crate::{
 
 use super::hooks::{AndromedaHook, OnFundsTransferResponse};
 
-pub const FACTORY_ADDRESS: &str = "terra1m2g9052ejs6em5cffwed83ywxzjgcvgqgp3rqk";
+pub const FACTORY_ADDRESS: &str = "terra1...";
 pub const MODULE_INFO: Map<&str, Module> = Map::new("andr_modules");
 pub const MODULE_ADDR: Map<&str, Addr> = Map::new("andr_module_addresses");
 pub const MODULE_IDX: Item<u64> = Item::new("andr_module_idx");

--- a/packages/andromeda_protocol/src/communication/modules.rs
+++ b/packages/andromeda_protocol/src/communication/modules.rs
@@ -272,13 +272,14 @@ pub fn validate_modules(modules: &[Module], ado_type: ADOType) -> Result<(), Con
 pub fn module_hook<T>(
     storage: &dyn Storage,
     querier: QuerierWrapper,
-    msg: AndromedaHook,
+    hook_msg: AndromedaHook,
 ) -> Result<Vec<T>, ContractError>
 where
     T: DeserializeOwned,
 {
     let addresses: Vec<String> = load_module_addresses(storage)?;
     let mut resp: Vec<T> = Vec::new();
+    let msg = HookMsg::AndrHook(hook_msg);
     for addr in addresses {
         let mod_resp: Result<T, StdError> = querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: addr,

--- a/packages/andromeda_protocol/src/factory.rs
+++ b/packages/andromeda_protocol/src/factory.rs
@@ -1,4 +1,4 @@
-use crate::modules::ModuleDefinition;
+use crate::{communication::AndromedaQuery, modules::ModuleDefinition};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -35,6 +35,7 @@ pub enum ExecuteMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
+    AndrQuery(AndromedaQuery),
     /// Query token contract address by its symbol
     GetAddress {
         symbol: String,

--- a/packages/andromeda_protocol/src/rates.rs
+++ b/packages/andromeda_protocol/src/rates.rs
@@ -1,9 +1,12 @@
 use crate::{
-    communication::{hooks::AndromedaHook, AndromedaMsg, AndromedaQuery, Recipient},
+    communication::{
+        hooks::{AndromedaHook, OnFundsTransferResponse},
+        AndromedaMsg, AndromedaQuery, Recipient,
+    },
     error::ContractError,
     modules::Rate,
 };
-use cosmwasm_std::{to_binary, Coin, QuerierWrapper, QueryRequest, SubMsg, WasmQuery};
+use cosmwasm_std::{to_binary, Coin, QuerierWrapper, QueryRequest, WasmQuery};
 use cw20::Cw20Coin;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -40,12 +43,6 @@ pub struct PaymentsResponse {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct DeductedFundsResponse {
-    pub msgs: Vec<SubMsg>,
-    pub leftover_funds: Funds,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct RateInfo {
     pub rate: Rate,
     pub is_additive: bool,
@@ -57,8 +54,8 @@ pub fn on_required_payments(
     querier: QuerierWrapper,
     addr: String,
     amount: Funds,
-) -> Result<DeductedFundsResponse, ContractError> {
-    let res: DeductedFundsResponse = querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
+) -> Result<OnFundsTransferResponse, ContractError> {
+    let res: OnFundsTransferResponse = querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
         contract_addr: addr,
         msg: to_binary(&QueryMsg::AndrQuery(AndromedaQuery::Get(Some(to_binary(
             &amount,

--- a/packages/andromeda_protocol/src/rates.rs
+++ b/packages/andromeda_protocol/src/rates.rs
@@ -30,7 +30,7 @@ pub enum ExecuteMsg {
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     AndrQuery(AndromedaQuery),
-    Hook(AndromedaHook),
+    AndrHook(AndromedaHook),
     Payments {},
 }
 


### PR DESCRIPTION
# Motivation
The contract won't work otherwise. 

# Implementation
- I added the communication protocol queries to the Factory ADO since the modules use that to get the code ids. 
- I wrapped some of the queries we were sending with `QueryMsg::AndrQuery(...)` or `HookMsg::AndrHook(...)` so they worked
- Replaced `wasm_instantiate` with raw `Instantiate` msg as that function was converting the message to binary, causing us to have a double encoding
- I refactored how we send hook queries to swallow up any `UnsupportedOperation` errors and bubble up the rest.

# Testing

## Unit/Integration tests
Not yet as I was just testing on chain.

## On-chain tests
These changes arose from creating an onchain test wherein I deployed a CW20 ADO with a Rates, Receipt, and AddressList module. The Rates contract had a single rate of 10% and the AddressList was configured as a whitelist. I was able to successfully instantiate the contract and transfer tokens to another wallet, all with the hooks working as they should.

# Future work
Reinforce these results with unit and integration tests. 