### PR TITLE
CU-1u5yywn | Add communication protocol messages to AddressList contract

### DIFF
--- a/contracts/andromeda_addresslist/src/contract.rs
+++ b/contracts/andromeda_addresslist/src/contract.rs
@@ -3,15 +3,20 @@ use andromeda_protocol::{
         add_address, includes_address, remove_address, ExecuteMsg, IncludesAddressResponse,
         InstantiateMsg, QueryMsg,
     },
-    communication::encode_binary,
+    communication::{encode_binary, parse_message, AndromedaMsg, AndromedaQuery},
     error::ContractError,
-    operators::{execute_update_operators, initialize_operators, is_operator, query_is_operator},
+    operators::{
+        execute_update_operators, initialize_operators, is_operator, query_is_operator,
+        query_operators,
+    },
     ownership::{execute_update_owner, query_contract_owner, CONTRACT_OWNER},
     require,
 };
-use cosmwasm_std::{attr, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Response};
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{attr, Binary, Deps, DepsMut, Env, MessageInfo, Response};
 
-#[entry_point]
+#[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
     deps: DepsMut,
     _env: Env,
@@ -26,18 +31,39 @@ pub fn instantiate(
     ]))
 }
 
-#[entry_point]
+#[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
     deps: DepsMut,
-    _env: Env,
+    env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     match msg {
+        ExecuteMsg::AndrReceive(msg) => execute_andr_receive(deps, env, info, msg),
         ExecuteMsg::AddAddress { address } => execute_add_address(deps, info, address),
         ExecuteMsg::RemoveAddress { address } => execute_remove_address(deps, info, address),
-        ExecuteMsg::UpdateOwner { address } => execute_update_owner(deps, info, address),
-        ExecuteMsg::UpdateOperator { operators } => execute_update_operators(deps, info, operators),
+    }
+}
+
+fn execute_andr_receive(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: AndromedaMsg,
+) -> Result<Response, ContractError> {
+    match msg {
+        AndromedaMsg::Receive(data) => {
+            let received: ExecuteMsg = parse_message(data)?;
+            match received {
+                ExecuteMsg::AndrReceive(..) => Err(ContractError::NestedAndromedaMsg {}),
+                _ => execute(deps, env, info, received),
+            }
+        }
+        AndromedaMsg::UpdateOwner { address } => execute_update_owner(deps, info, address),
+        AndromedaMsg::UpdateOperators { operators } => {
+            execute_update_operators(deps, info, operators)
+        }
+        AndromedaMsg::Withdraw { .. } => Err(ContractError::UnsupportedOperation {}),
     }
 }
 
@@ -76,12 +102,32 @@ fn execute_remove_address(
     ]))
 }
 
-#[entry_point]
-pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
     match msg {
         QueryMsg::IncludesAddress { address } => encode_binary(&query_address(deps, &address)?),
-        QueryMsg::ContractOwner {} => encode_binary(&query_contract_owner(deps)?),
-        QueryMsg::IsOperator { address } => encode_binary(&query_is_operator(deps, &address)?),
+        QueryMsg::AndrQuery(msg) => handle_andromeda_query(deps, env, msg),
+    }
+}
+
+fn handle_andromeda_query(
+    deps: Deps,
+    env: Env,
+    msg: AndromedaQuery,
+) -> Result<Binary, ContractError> {
+    match msg {
+        AndromedaQuery::Get(data) => {
+            let received: QueryMsg = parse_message(data)?;
+            match received {
+                QueryMsg::AndrQuery(..) => Err(ContractError::NestedAndromedaMsg {}),
+                _ => query(deps, env, received),
+            }
+        }
+        AndromedaQuery::Owner {} => encode_binary(&query_contract_owner(deps)?),
+        AndromedaQuery::Operators {} => encode_binary(&query_operators(deps)?),
+        AndromedaQuery::IsOperator { address } => {
+            encode_binary(&query_is_operator(deps, &address)?)
+        }
     }
 }
 

--- a/packages/andromeda_protocol/src/address_list.rs
+++ b/packages/andromeda_protocol/src/address_list.rs
@@ -79,7 +79,7 @@ pub enum QueryMsg {
     AndrQuery(AndromedaQuery),
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct IncludesAddressResponse {
     /// Whether the address is included in the address list
     pub included: bool,

--- a/packages/andromeda_protocol/src/address_list.rs
+++ b/packages/andromeda_protocol/src/address_list.rs
@@ -1,4 +1,7 @@
-use crate::error::ContractError;
+use crate::{
+    communication::{AndromedaMsg, AndromedaQuery},
+    error::ContractError,
+};
 use cosmwasm_std::{to_binary, QuerierWrapper, QueryRequest, StdResult, Storage, WasmQuery};
 use cw_storage_plus::Map;
 use schemars::JsonSchema;
@@ -55,6 +58,7 @@ pub struct InstantiateMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
+    AndrReceive(AndromedaMsg),
     /// Add an address to the address list
     AddAddress {
         address: String,
@@ -62,13 +66,6 @@ pub enum ExecuteMsg {
     /// Remove an address from the address list
     RemoveAddress {
         address: String,
-    },
-    /// Update ownership of the contract
-    UpdateOwner {
-        address: String,
-    },
-    UpdateOperator {
-        operators: Vec<String>,
     },
 }
 
@@ -79,11 +76,7 @@ pub enum QueryMsg {
     IncludesAddress {
         address: String,
     },
-    /// Query the current contract owner
-    ContractOwner {},
-    IsOperator {
-        address: String,
-    },
+    AndrQuery(AndromedaQuery),
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema)]

--- a/packages/andromeda_protocol/src/modules/common.rs
+++ b/packages/andromeda_protocol/src/modules/common.rs
@@ -70,7 +70,7 @@ pub fn is_unique<M: Module>(module: &M, all_modules: &[ModuleDefinition]) -> boo
 /// ## Arguments
 /// * `coins` - The vector of `Coin` structs from which to deduct the given funds
 /// * `funds` - The amount to deduct
-pub fn deduct_funds(coins: &mut Vec<Coin>, funds: &Coin) -> Result<bool, ContractError> {
+pub fn deduct_funds(coins: &mut [Coin], funds: &Coin) -> Result<bool, ContractError> {
     let coin_amount = coins.iter_mut().find(|c| c.denom.eq(&funds.denom));
 
     match coin_amount {
@@ -110,7 +110,7 @@ pub fn add_payment(payments: &mut Vec<BankMsg>, to: String, amount: Coin) {
 ///
 /// Errors if there is no payment from which to deduct the funds
 pub fn deduct_payment(
-    payments: &mut Vec<BankMsg>,
+    payments: &mut [BankMsg],
     to: String,
     amount: Coin,
 ) -> Result<bool, ContractError> {

--- a/packages/andromeda_protocol/src/modules/hooks.rs
+++ b/packages/andromeda_protocol/src/modules/hooks.rs
@@ -197,6 +197,7 @@ pub trait MessageHooks {
         Ok(HookResponse::default())
     }
     /// Called whenever an agreed transfer is taking place
+    #[allow(clippy::ptr_arg)]
     fn on_agreed_transfer(
         &self,
         _deps: &DepsMut,


### PR DESCRIPTION
# Motivation
This was missed during the original updating of contracts but it is necessary to have a standard messaging API between our contracts. 

# Implementation
Just added `AndromedaMsg` and `AndromedaQuery` enums as possible messages. `AndromedaMsg` uses the default approach while `AndromedaQuery::Get` assumes the payload is an address and checks if it is included in the whitelist or not.

# Testing

## Unit/Integration tests
I added a unit test for testing the `AndromedaQuery::Get` behaviour.

## On-chain tests
None needed.

# Future work
n/a