### PR TITLE
CU-1u5yywn | Add communication protocol messages to Factory contract

### DIFF
--- a/packages/andromeda_protocol/src/factory.rs
+++ b/packages/andromeda_protocol/src/factory.rs
@@ -1,4 +1,7 @@
-use crate::modules::ModuleDefinition;
+use crate::{
+    communication::{AndromedaMsg, AndromedaQuery},
+    modules::ModuleDefinition,
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -23,13 +26,7 @@ pub enum ExecuteMsg {
         symbol: String,
         new_address: String,
     },
-    /// Update current contract owner
-    UpdateOwner {
-        address: String,
-    },
-    UpdateOperator {
-        operators: Vec<String>,
-    },
+    AndrReceive(AndromedaMsg),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -43,11 +40,7 @@ pub enum QueryMsg {
     CodeId {
         key: String,
     },
-    /// The current contract owner
-    ContractOwner {},
-    IsOperator {
-        address: String,
-    },
+    AndrQuery(AndromedaQuery),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/andromeda_protocol/src/modules/common.rs
+++ b/packages/andromeda_protocol/src/modules/common.rs
@@ -70,7 +70,7 @@ pub fn is_unique<M: Module>(module: &M, all_modules: &[ModuleDefinition]) -> boo
 /// ## Arguments
 /// * `coins` - The vector of `Coin` structs from which to deduct the given funds
 /// * `funds` - The amount to deduct
-pub fn deduct_funds(coins: &mut Vec<Coin>, funds: &Coin) -> Result<bool, ContractError> {
+pub fn deduct_funds(coins: &mut [Coin], funds: &Coin) -> Result<bool, ContractError> {
     let coin_amount = coins.iter_mut().find(|c| c.denom.eq(&funds.denom));
 
     match coin_amount {
@@ -110,7 +110,7 @@ pub fn add_payment(payments: &mut Vec<BankMsg>, to: String, amount: Coin) {
 ///
 /// Errors if there is no payment from which to deduct the funds
 pub fn deduct_payment(
-    payments: &mut Vec<BankMsg>,
+    payments: &mut [BankMsg],
     to: String,
     amount: Coin,
 ) -> Result<bool, ContractError> {

--- a/packages/andromeda_protocol/src/modules/hooks.rs
+++ b/packages/andromeda_protocol/src/modules/hooks.rs
@@ -197,6 +197,7 @@ pub trait MessageHooks {
         Ok(HookResponse::default())
     }
     /// Called whenever an agreed transfer is taking place
+    #[allow(clippy::ptr_arg)]
     fn on_agreed_transfer(
         &self,
         _deps: &DepsMut,


### PR DESCRIPTION
# Motivation
This was missed during the original updating of contracts but it is necessary to have a standard messaging API between our contracts. 

# Implementation
Just added `AndromedaMsg` and `AndromedaQuery` enums as possible messages using the standard approach.

# Testing

## Unit/Integration tests
None needed.

## On-chain tests
None needed.

# Future work
n/a