### PR TITLE
Add events for Rate payments to be storable in a Receipt

### DIFF
--- a/packages/andromeda_protocol/src/rates.rs
+++ b/packages/andromeda_protocol/src/rates.rs
@@ -50,6 +50,20 @@ pub struct RateInfo {
     pub receivers: Vec<Recipient>,
 }
 
+/// An attribute struct used for any events that involve a payment
+pub struct PaymentAttribute {
+    /// The amount paid
+    pub amount: Coin,
+    /// The address the payment was made to
+    pub receiver: String,
+}
+
+impl ToString for PaymentAttribute {
+    fn to_string(&self) -> String {
+        format!("{}<{}", self.receiver, self.amount)
+    }
+}
+
 pub fn on_required_payments(
     querier: QuerierWrapper,
     addr: String,


### PR DESCRIPTION
# Motivation
The old modules `Taxable` and `Royalties` both created events to be stored in a `Receipt` which was useful so I ported that logic over to be used in the `Rates contract` as that is the new approach.

# Implementation
I took the exact same implementation as was done in `Taxable` and `Royalties` and added it to the `fn query_deducted_funds(...)` function of the `Rates` contract.

# Testing

## Unit/Integration tests
I updated the existing unit tests in the `Rates` contract to test that the events were correctly generated.

## On-chain tests
No as this change is fairly simple and we already know that the Receipt gets created properly from previous on-chain tests.

# Future work
Right now the formatting for cw20 tokens in the events is a bit rough as it uses the same format as the native coins. It might be desirable to give them a different format in the future, but it is not a priority right now.