### PR TITLE
CU-1wardu5 | Cw721

### DIFF
--- a/.github/file-size.sh
+++ b/.github/file-size.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-find ./artifacts -maxdepth 1 -size +575k | while read file; do
+find ./artifacts -maxdepth 1 -size +600k | while read file; do
   echo "$file is too large: $(wc -c "$file" | awk '{print $1}') bytes. Maximum: 575000 bytes."
   exit 1
 done

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "cw20 0.9.1",
  "cw20-base",
  "cw721",
+ "cw721-base",
  "mirror-protocol",
  "schemars",
  "serde",

--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/workspace-optimizer:0.12.3
+  cosmwasm/workspace-optimizer:0.12.5

--- a/contracts/andromeda_cw721/.cargo/config
+++ b/contracts/andromeda_cw721/.cargo/config
@@ -1,0 +1,4 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+schema = "run --example schema"

--- a/contracts/andromeda_cw721/.editorconfig
+++ b/contracts/andromeda_cw721/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.rs]
+indent_size = 4

--- a/contracts/andromeda_cw721/.gitignore
+++ b/contracts/andromeda_cw721/.gitignore
@@ -1,0 +1,15 @@
+# Build results
+/target
+
+# Cargo+Git helper file (https://github.com/rust-lang/cargo/blob/0.44.1/src/cargo/sources/git/utils.rs#L320-L327)
+.cargo-ok
+
+# Text file backups
+**/*.rs.bk
+
+# macOS
+.DS_Store
+
+# IDEs
+*.iml
+.idea

--- a/contracts/andromeda_cw721/Cargo.lock
+++ b/contracts/andromeda_cw721/Cargo.lock
@@ -3,193 +3,6 @@
 version = 3
 
 [[package]]
-name = "andromeda-addresslist"
-version = "0.1.0"
-dependencies = [
- "andromeda-protocol",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cosmwasm-storage",
- "cw-storage-plus 0.9.1",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "andromeda-anchor"
-version = "0.1.0"
-dependencies = [
- "andromeda-protocol",
- "cosmwasm-std",
- "cw-storage-plus 0.9.1",
- "cw20 0.9.1",
- "schemars",
- "serde",
- "terra-cosmwasm",
- "terraswap",
-]
-
-[[package]]
-name = "andromeda-cw20"
-version = "0.1.0"
-dependencies = [
- "andromeda-protocol",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus 0.9.1",
- "cw20 0.9.1",
- "cw20-base",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "andromeda-cw721"
-version = "0.1.0"
-dependencies = [
- "andromeda-protocol",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus 0.9.1",
- "cw721",
- "cw721-base",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "andromeda-factory"
-version = "0.1.0"
-dependencies = [
- "andromeda-protocol",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus 0.9.1",
- "cw721",
- "schemars",
- "serde",
- "terra-cosmwasm",
-]
-
-[[package]]
-name = "andromeda-mirror-wrapped-cdp"
-version = "0.1.0"
-dependencies = [
- "andromeda-protocol",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cosmwasm-storage",
- "cw-storage-plus 0.8.1",
- "cw2 0.8.1",
- "cw20 0.9.1",
- "mirror-protocol",
- "schemars",
- "serde",
- "terra-cosmwasm",
- "terraswap",
- "thiserror",
-]
-
-[[package]]
-name = "andromeda-primitive"
-version = "0.1.0"
-dependencies = [
- "andromeda-protocol",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cosmwasm-storage",
- "cw-storage-plus 0.8.1",
- "cw2 0.8.1",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "andromeda-protocol"
-version = "0.1.0"
-dependencies = [
- "cosmwasm-std",
- "cw-storage-plus 0.9.1",
- "cw0 0.9.1",
- "cw20 0.9.1",
- "cw20-base",
- "cw721",
- "mirror-protocol",
- "schemars",
- "serde",
- "terra-cosmwasm",
- "terraswap",
- "thiserror",
-]
-
-[[package]]
-name = "andromeda-rates"
-version = "0.1.0"
-dependencies = [
- "andromeda-protocol",
- "cosmwasm-std",
- "cosmwasm-storage",
- "cw-storage-plus 0.9.1",
- "cw20 0.9.1",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "andromeda-receipt"
-version = "0.1.0"
-dependencies = [
- "andromeda-protocol",
- "cosmwasm-std",
- "cosmwasm-storage",
- "cw-storage-plus 0.9.1",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "andromeda-splitter"
-version = "0.1.0"
-dependencies = [
- "andromeda-protocol",
- "cosmwasm-std",
- "cosmwasm-storage",
- "cw-storage-plus 0.9.1",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "andromeda-timelock"
-version = "0.1.0"
-dependencies = [
- "andromeda-protocol",
- "cosmwasm-std",
- "cw-storage-plus 0.9.1",
- "cw721",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "andromeda-token"
-version = "0.1.0"
-dependencies = [
- "andromeda-protocol",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus 0.9.1",
- "cw721",
- "schemars",
- "serde",
- "terra-cosmwasm",
-]
-
-[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,15 +31,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.6.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
+checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "0.16.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec9bdd1f4da5fc0d085251b0322661c5aaf773ab299e3e205fb18130b7f6ba3"
+checksum = "bfa1715a9b71c7c31385a3f021dee2fd0a17b82043ab937467e103aa25043d2e"
 dependencies = [
  "digest",
  "ed25519-zebra",
@@ -237,18 +50,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "0.16.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac17a14b4ab09a5d89b5301218067acca33d9311376e5c34c9877f09e562395"
+checksum = "9f6e6dff07965015c4fcdf477c4becde738a2bfb40cf6239bdcea9335016c5a2"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.16.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c04830bc186c970ea400c0ea56f8a61b19aea1aa8d2442b9f9f9de96a61f0bf0"
+checksum = "ac9ba1eea088e7f1ec4a7679c43adcb51e80cbc2af6a6d83d1bb652b7adaf6dc"
 dependencies = [
  "schemars",
  "serde_json",
@@ -256,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.16.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47306c113f4d964c35a74a87ceb8ccfb5811e9810a9dc427101148b5b9134ca"
+checksum = "92bdeee0ebba164ebbef9380522cc50f889db38acc1f1210f6b55ee2244b8c59"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -272,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "0.16.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e3472d8e0e7155c5f4d89674ad47adede4b1491ad14f4141610e1522028a6a7"
+checksum = "e26053f14f971b05abca3be34f80c631d70c5b5b9df175e7a1d8b4aad83e40cc"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -282,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
 dependencies = [
  "libc",
 ]
@@ -297,9 +110,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.11"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
+checksum = "b32a398eb1ccfbe7e4f452bc749c44d38dd732e9a253f19da224c416f00ee7f4"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -332,147 +145,20 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.8.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e867b9972b83b32e00e878dfbff48299ba26618dabeb19b9c56fae176dc225"
+checksum = "6ef70f7912bed72ff56a4f704aee279b6ef4cd0a5f3aa2732ad371e3f6d3ea71"
 dependencies = [
  "cosmwasm-std",
  "schemars",
  "serde",
-]
-
-[[package]]
-name = "cw-storage-plus"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e401ed71bd64abb9b91151a9ff4f7b34e81b2b3eceab23e3cb67fe47e39938"
-dependencies = [
- "cosmwasm-std",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw0"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c497f885a40918a02df7d938c81809965fa05cfc21b3dc591e9950237b5de0a9"
-dependencies = [
- "cosmwasm-std",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "cw0"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d759bb5418a3bdf091e1f1be17de2a15d95d2be4fee28045c2e461f4c6d9d1ca"
-dependencies = [
- "cosmwasm-std",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "cw2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d48454f96494aa1018556cd457977375cc8c57ef3e5c767cfa2ea5ec24b0258"
-dependencies = [
- "cosmwasm-std",
- "cw-storage-plus 0.8.1",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw2"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6380164fb236412ff43c7ca075d95847c6fa8c51b2d3a513c23127a0f2a8f6"
-dependencies = [
- "cosmwasm-std",
- "cw-storage-plus 0.9.1",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw20"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a11a2adbd52258f5b4ed5323f62bc6e559f2cefbe52ef0e58290016fde5bb083"
-dependencies = [
- "cosmwasm-std",
- "cw0 0.8.1",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw20"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac49b013ca1e355fd988cc1926acc9a16d7fd45cfb595ee330455582a788b100"
-dependencies = [
- "cosmwasm-std",
- "cw0 0.9.1",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw20-base"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b731a291b63cc26d484b159e8469f0965b0082a20e874616f869537b31d64bb"
-dependencies = [
- "cosmwasm-std",
- "cw-storage-plus 0.9.1",
- "cw0 0.9.1",
- "cw2 0.9.1",
- "cw20 0.9.1",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "cw721"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44a81e5d775c056f5c1dd5eaaf68b82599cbc21d21c9a38eca0b74808d934806"
-dependencies = [
- "cosmwasm-std",
- "cw0 0.9.1",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw721-base"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239bdfcae1ba72cfcdd3e4eb6300eea2673b63f74425ece5b6bc45cf964fbc1a"
-dependencies = [
- "cosmwasm-std",
- "cw-storage-plus 0.9.1",
- "cw0 0.9.1",
- "cw2 0.9.1",
- "cw721",
- "schemars",
- "serde",
- "thiserror",
 ]
 
 [[package]]
 name = "der"
-version = "0.4.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28e98c534e9c8a0483aa01d6f6913bc063de254311bd267c9cf535e9b70e15b2"
+checksum = "31e21d2d0f22cde6e88694108429775c0219760a07779bf96503b434a03d7412"
 dependencies = [
  "const-oid",
 ]
@@ -494,9 +180,9 @@ checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "ecdsa"
-version = "0.12.4"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
+checksum = "713c32426287891008edb98f8b5c6abb2130aa043c93a818728fcda78606f274"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -520,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.6"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
+checksum = "069397e10739989e400628cbc0556a817a8a64119d7a2315767f4456e1332c23"
 dependencies = [
  "crypto-bigint",
  "ff",
@@ -536,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
+checksum = "63eec06c61e487eecf0f7e6e6372e596a81922c28d33e645d6983ca6493a1af0"
 dependencies = [
  "rand_core 0.6.3",
  "subtle",
@@ -605,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "k256"
@@ -623,23 +309,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.108"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
-
-[[package]]
-name = "mirror-protocol"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b4a3ba65a8fd11cd24862cc49a2c4eebb98e8dfd38d43df72145cde19d9ca6"
-dependencies = [
- "cosmwasm-std",
- "cosmwasm-storage",
- "cw20 0.8.1",
- "schemars",
- "serde",
- "terraswap",
-]
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "opaque-debug"
@@ -649,9 +321,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pkcs8"
-version = "0.7.6"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
+checksum = "fbee84ed13e44dd82689fa18348a49934fa79cc774a344c42fc9b301c71b140a"
 dependencies = [
  "der",
  "spki",
@@ -659,18 +331,31 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
+name = "project-name"
+version = "0.1.0"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw-storage-plus",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -701,9 +386,9 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "schemars"
-version = "0.8.7"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271ac0c667b8229adf70f0f957697c96fafd7486ab7481e15dc5e45e3e6a4368"
+checksum = "bc6ab463ae35acccb5cba66c0084c985257b797d288b6050cc2f6ac1b266cb78"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -713,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.7"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ebda811090b257411540779860bc09bf321bc587f58d2c5864309d1566214e7"
+checksum = "902fdfbcf871ae8f653bddf4b2c05905ddaabc08f69d32a915787e3be0d31356"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -725,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
@@ -743,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -765,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.71"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063bf466a64011ac24040a49009724ee60a57da1b437617ceb32e53ad61bfb19"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",
@@ -776,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.8"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
+checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer",
  "cfg-if",
@@ -789,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 dependencies = [
  "digest",
  "rand_core 0.6.3",
@@ -799,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
+checksum = "987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521"
 dependencies = [
  "der",
 ]
@@ -820,9 +505,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -830,44 +515,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "terra-cosmwasm"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552f18cba2b535d1f8c0e3b3f37696820b954bc7535d2e33909f2a6342302718"
-dependencies = [
- "cosmwasm-std",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "terraswap"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96f2c2a6371e9ddf2c942368e64645cc3e8fc2855da70c8c6bed238dcdd5522f"
-dependencies = [
- "cosmwasm-std",
- "cosmwasm-storage",
- "cw20 0.8.1",
- "schemars",
- "serde",
- "terra-cosmwasm",
-]
-
-[[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -876,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.14.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "uint"
@@ -918,6 +578,6 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "zeroize"
-version = "1.4.3"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
+checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"

--- a/contracts/andromeda_cw721/Cargo.toml
+++ b/contracts/andromeda_cw721/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "andromeda-cw721"
+version = "0.1.0"
+authors = ["Connor Barr <crnbarr@gmail.com>"]
+edition = "2018"
+
+exclude = [
+  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+  "contract.wasm",
+  "hash.txt",
+]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+panic = 'abort'
+incremental = false
+overflow-checks = true
+
+[features]
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+
+[package.metadata.scripts]
+optimize = """docker run --rm -v "$(pwd)":/code \
+  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
+  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
+  cosmwasm/rust-optimizer:0.12.3
+"""
+
+[dependencies]
+cosmwasm-std = "0.16.0"
+cw-storage-plus = "0.9.1"
+schemars = "0.8.3"
+serde = { version = "1.0.127", default-features = false, features = ["derive"] }
+andromeda-protocol = { version = "0.1.0", path = "../../packages/andromeda_protocol" }
+cw721 = "0.9.1"
+cw721-base = { version = "0.9.1", features = ["library"] }
+thiserror = { version = "1.0.26" }
+
+[dev-dependencies]
+cosmwasm-schema = { version = "0.16.0" }

--- a/contracts/andromeda_cw721/examples/schema.rs
+++ b/contracts/andromeda_cw721/examples/schema.rs
@@ -1,0 +1,16 @@
+use std::env::current_dir;
+use std::fs::create_dir_all;
+
+use andromeda_protocol::cw20::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
+
+fn main() {
+    let mut out_dir = current_dir().unwrap();
+    out_dir.push("schema");
+    create_dir_all(&out_dir).unwrap();
+    remove_schemas(&out_dir).unwrap();
+
+    export_schema(&schema_for!(InstantiateMsg), &out_dir);
+    export_schema(&schema_for!(ExecuteMsg), &out_dir);
+    export_schema(&schema_for!(QueryMsg), &out_dir);
+}

--- a/contracts/andromeda_cw721/rustfmt.toml
+++ b/contracts/andromeda_cw721/rustfmt.toml
@@ -1,0 +1,15 @@
+# stable
+newline_style = "unix"
+hard_tabs = false
+tab_spaces = 4
+
+# unstable... should we require `rustup run nightly cargo fmt` ?
+# or just update the style guide when they are stable?
+#fn_single_line = true
+#format_code_in_doc_comments = true
+#overflow_delimited_expr = true
+#reorder_impl_items = true
+#struct_field_align_threshold = 20
+#struct_lit_single_line = true
+#report_todo = "Always"
+

--- a/contracts/andromeda_cw721/schema/count_response.json
+++ b/contracts/andromeda_cw721/schema/count_response.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CountResponse",
+  "type": "object",
+  "required": [
+    "count"
+  ],
+  "properties": {
+    "count": {
+      "type": "integer",
+      "format": "int32"
+    }
+  }
+}

--- a/contracts/andromeda_cw721/schema/execute_msg.json
+++ b/contracts/andromeda_cw721/schema/execute_msg.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ExecuteMsg",
+  "anyOf": [
+    {
+      "type": "object",
+      "required": [
+        "increment"
+      ],
+      "properties": {
+        "increment": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "reset"
+      ],
+      "properties": {
+        "reset": {
+          "type": "object",
+          "required": [
+            "count"
+          ],
+          "properties": {
+            "count": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  ]
+}

--- a/contracts/andromeda_cw721/schema/instantiate_msg.json
+++ b/contracts/andromeda_cw721/schema/instantiate_msg.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "InstantiateMsg",
+  "type": "object",
+  "required": [
+    "count"
+  ],
+  "properties": {
+    "count": {
+      "type": "integer",
+      "format": "int32"
+    }
+  }
+}

--- a/contracts/andromeda_cw721/schema/query_msg.json
+++ b/contracts/andromeda_cw721/schema/query_msg.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "QueryMsg",
+  "anyOf": [
+    {
+      "type": "object",
+      "required": [
+        "get_count"
+      ],
+      "properties": {
+        "get_count": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    }
+  ]
+}

--- a/contracts/andromeda_cw721/schema/state.json
+++ b/contracts/andromeda_cw721/schema/state.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "State",
+  "type": "object",
+  "required": [
+    "count",
+    "owner"
+  ],
+  "properties": {
+    "count": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "owner": {
+      "$ref": "#/definitions/Addr"
+    }
+  },
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/andromeda_cw721/src/contract.rs
+++ b/contracts/andromeda_cw721/src/contract.rs
@@ -9,8 +9,8 @@ use andromeda_protocol::{
     communication::{
         hooks::AndromedaHook,
         modules::{
-            execute_register_module, module_hook, on_funds_transfer, validate_modules, ADOType,
-            MODULE_ADDR, MODULE_INFO,
+            execute_alter_module, execute_deregister_module, execute_register_module, module_hook,
+            on_funds_transfer, validate_modules, ADOType, MODULE_ADDR, MODULE_INFO,
         },
     },
     cw721::{ExecuteMsg, InstantiateMsg, QueryMsg, TokenExtension, TransferAgreement},
@@ -131,6 +131,21 @@ pub fn execute(
             execute_update_pricing(deps, env, info, token_id, price)
         }
         ExecuteMsg::Archive { token_id } => execute_archive(deps, env, info, token_id),
+        ExecuteMsg::RegisterModule { module } => execute_register_module(
+            &deps.querier,
+            deps.storage,
+            deps.api,
+            info.sender.as_str(),
+            &module,
+            ADOType::CW20,
+            true,
+        ),
+        ExecuteMsg::DeregisterModule { module_idx } => {
+            execute_deregister_module(deps, info, module_idx)
+        }
+        ExecuteMsg::AlterModule { module_idx, module } => {
+            execute_alter_module(deps, info, module_idx, &module, ADOType::CW721)
+        }
         _ => Ok(AndrCW721Contract::default().execute(deps, env, info, msg.into())?),
     }
 }

--- a/contracts/andromeda_cw721/src/contract.rs
+++ b/contracts/andromeda_cw721/src/contract.rs
@@ -1,0 +1,246 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{
+    from_binary, to_binary, Addr, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Reply,
+    Response, StdError, StdResult, Storage, Uint128, WasmMsg,
+};
+
+use andromeda_protocol::{
+    communication::{
+        hooks::AndromedaHook,
+        modules::{
+            execute_alter_module, execute_deregister_module, execute_register_module, module_hook,
+            on_funds_transfer, validate_modules, ADOType, MODULE_ADDR, MODULE_INFO,
+        },
+    },
+    cw20::{ExecuteMsg, InstantiateMsg, QueryMsg},
+    error::ContractError,
+    ownership::CONTRACT_OWNER,
+    rates::Funds,
+    require,
+    response::get_reply_address,
+};
+use cw721_base::Cw721Contract;
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    CONTRACT_OWNER.save(deps.storage, &info.sender)?;
+    let mut resp = Response::default();
+    let sender = info.sender.as_str();
+    if let Some(modules) = msg.modules.clone() {
+        validate_modules(&modules, ADOType::CW20)?;
+        for module in modules {
+            resp = execute_register_module(
+                &deps.querier,
+                deps.storage,
+                deps.api,
+                sender,
+                &module,
+                ADOType::CW20,
+                false,
+            )?;
+        }
+    }
+    let cw20_resp = cw20_instantiate(deps, env, info, msg.into())?;
+    resp = resp
+        .add_submessages(cw20_resp.messages)
+        .add_attributes(cw20_resp.attributes);
+
+    Ok(resp)
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractError> {
+    if msg.result.is_err() {
+        return Err(ContractError::Std(StdError::generic_err(
+            msg.result.unwrap_err(),
+        )));
+    }
+
+    let id = msg.id.to_string();
+    require(
+        MODULE_INFO.load(deps.storage, &id).is_ok(),
+        ContractError::InvalidReplyId {},
+    )?;
+
+    let addr = get_reply_address(&msg)?;
+    MODULE_ADDR.save(deps.storage, &id, &deps.api.addr_validate(&addr)?)?;
+
+    Ok(Response::default())
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    module_hook::<Response>(
+        deps.storage,
+        deps.querier,
+        AndromedaHook::OnExecute {
+            sender: info.sender.to_string(),
+            payload: to_binary(&msg)?,
+        },
+    )?;
+    match msg {
+        ExecuteMsg::Transfer { recipient, amount } => {
+            execute_transfer(deps, env, info, recipient, amount)
+        }
+        ExecuteMsg::Burn { amount } => execute_burn(deps, env, info, amount),
+        ExecuteMsg::Send {
+            contract,
+            amount,
+            msg,
+        } => execute_send(deps, env, info, contract, amount, msg),
+        ExecuteMsg::Mint { recipient, amount } => execute_mint(deps, env, info, recipient, amount),
+        ExecuteMsg::RegisterModule { module } => execute_register_module(
+            &deps.querier,
+            deps.storage,
+            deps.api,
+            info.sender.as_str(),
+            &module,
+            ADOType::CW20,
+            true,
+        ),
+        ExecuteMsg::DeregisterModule { module_idx } => {
+            execute_deregister_module(deps, info, module_idx)
+        }
+        ExecuteMsg::AlterModule { module_idx, module } => {
+            execute_alter_module(deps, info, module_idx, &module, ADOType::CW20)
+        }
+        _ => Ok(execute_cw20(deps, env, info, msg.into())?),
+    }
+}
+
+fn execute_transfer(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    recipient: String,
+    amount: Uint128,
+) -> Result<Response, ContractError> {
+    let mut resp = Response::new();
+    let sender = info.sender.clone();
+    let (payments, events, remainder) = on_funds_transfer(
+        deps.storage,
+        deps.querier,
+        info.sender.to_string(),
+        Funds::Cw20(Cw20Coin {
+            address: env.contract.address.to_string(),
+            amount,
+        }),
+        to_binary(&ExecuteMsg::Transfer {
+            amount,
+            recipient: recipient.clone(),
+        })?,
+    )?;
+    let remaining_amount = match remainder {
+        Funds::Native(..) => amount, //What do we do in the case that the rates returns remaining amount as native funds?
+        Funds::Cw20(coin) => coin.amount,
+    };
+
+    // Filter through payment messages to extract cw20 transfer messages to avoid looping
+    for msg in payments {
+        match msg.msg.clone() {
+            // Transfer messages are CosmosMsg::Wasm type
+            CosmosMsg::Wasm(wasm_msg) => match wasm_msg {
+                WasmMsg::Execute { msg: exec_msg, .. } => {
+                    // If binary deserializes to a Cw20ExecuteMsg check the message type
+                    if let Ok(transfer_msg) = from_binary::<Cw20ExecuteMsg>(&exec_msg) {
+                        match transfer_msg {
+                            // If the message is a transfer message then transfer the tokens from the current message sender to the recipient
+                            Cw20ExecuteMsg::Transfer { recipient, amount } => {
+                                transfer_tokens(
+                                    deps.storage,
+                                    sender.clone(),
+                                    deps.api.addr_validate(&recipient)?,
+                                    amount,
+                                )?;
+                            }
+                            // Otherwise add to messages to be sent in response
+                            _ => {
+                                resp = resp.add_submessage(msg);
+                            }
+                        }
+                    }
+                }
+                // Otherwise add to messages to be sent in response
+                _ => {
+                    resp = resp.add_submessage(msg.clone());
+                }
+            },
+            // Otherwise add to messages to be sent in response
+            _ => {
+                resp = resp.add_submessage(msg);
+            }
+        }
+    }
+
+    // Continue with standard cw20 operation
+    let cw20_resp = execute_cw20_transfer(deps, env, info, recipient, remaining_amount)?;
+    resp = resp.add_attributes(cw20_resp.attributes).add_events(events);
+    Ok(resp)
+}
+
+fn transfer_tokens(
+    storage: &mut dyn Storage,
+    sender: Addr,
+    recipient: Addr,
+    amount: Uint128,
+) -> Result<(), ContractError> {
+    BALANCES.update(
+        storage,
+        &sender,
+        |balance: Option<Uint128>| -> StdResult<_> {
+            Ok(balance.unwrap_or_default().checked_sub(amount)?)
+        },
+    )?;
+    BALANCES.update(
+        storage,
+        &recipient,
+        |balance: Option<Uint128>| -> StdResult<_> { Ok(balance.unwrap_or_default() + amount) },
+    )?;
+    Ok(())
+}
+
+fn execute_burn(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    amount: Uint128,
+) -> Result<Response, ContractError> {
+    Ok(execute_cw20_burn(deps, env, info, amount)?)
+}
+
+fn execute_send(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    contract: String,
+    amount: Uint128,
+    msg: Binary,
+) -> Result<Response, ContractError> {
+    Ok(execute_cw20_send(deps, env, info, contract, amount, msg)?)
+}
+
+fn execute_mint(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    recipient: String,
+    amount: Uint128,
+) -> Result<Response, ContractError> {
+    Ok(execute_cw20_mint(deps, env, info, recipient, amount)?)
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
+    Ok(query_cw20(deps, env, msg.into())?)
+}

--- a/contracts/andromeda_cw721/src/contract.rs
+++ b/contracts/andromeda_cw721/src/contract.rs
@@ -1,26 +1,27 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    from_binary, to_binary, Addr, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Reply,
-    Response, StdError, StdResult, Storage, Uint128, WasmMsg,
+    to_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Reply, Response, StdError, Uint128,
 };
 
 use andromeda_protocol::{
     communication::{
         hooks::AndromedaHook,
         modules::{
-            execute_alter_module, execute_deregister_module, execute_register_module, module_hook,
-            on_funds_transfer, validate_modules, ADOType, MODULE_ADDR, MODULE_INFO,
+            execute_register_module, module_hook, validate_modules, ADOType, MODULE_ADDR,
+            MODULE_INFO,
         },
     },
-    cw20::{ExecuteMsg, InstantiateMsg, QueryMsg},
+    cw721::{InstantiateMsg, QueryMsg, TokenExtension},
     error::ContractError,
     ownership::CONTRACT_OWNER,
-    rates::Funds,
     require,
     response::get_reply_address,
+    token::ExecuteMsg,
 };
 use cw721_base::Cw721Contract;
+
+pub type AndrCW721Contract<'a> = Cw721Contract<'a, TokenExtension, Empty>;
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
@@ -30,10 +31,11 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
     CONTRACT_OWNER.save(deps.storage, &info.sender)?;
-    let mut resp = Response::default();
+
     let sender = info.sender.as_str();
+    let mut resp = Response::default();
     if let Some(modules) = msg.modules.clone() {
-        validate_modules(&modules, ADOType::CW20)?;
+        validate_modules(&modules, ADOType::CW721)?;
         for module in modules {
             resp = execute_register_module(
                 &deps.querier,
@@ -46,11 +48,10 @@ pub fn instantiate(
             )?;
         }
     }
-    let cw20_resp = cw20_instantiate(deps, env, info, msg.into())?;
+    let cw721_resp = AndrCW721Contract::default().instantiate(deps, env, info, msg.into())?;
     resp = resp
-        .add_submessages(cw20_resp.messages)
-        .add_attributes(cw20_resp.attributes);
-
+        .add_attributes(cw721_resp.attributes)
+        .add_submessages(cw721_resp.messages);
     Ok(resp)
 }
 
@@ -89,34 +90,8 @@ pub fn execute(
             payload: to_binary(&msg)?,
         },
     )?;
-    match msg {
-        ExecuteMsg::Transfer { recipient, amount } => {
-            execute_transfer(deps, env, info, recipient, amount)
-        }
-        ExecuteMsg::Burn { amount } => execute_burn(deps, env, info, amount),
-        ExecuteMsg::Send {
-            contract,
-            amount,
-            msg,
-        } => execute_send(deps, env, info, contract, amount, msg),
-        ExecuteMsg::Mint { recipient, amount } => execute_mint(deps, env, info, recipient, amount),
-        ExecuteMsg::RegisterModule { module } => execute_register_module(
-            &deps.querier,
-            deps.storage,
-            deps.api,
-            info.sender.as_str(),
-            &module,
-            ADOType::CW20,
-            true,
-        ),
-        ExecuteMsg::DeregisterModule { module_idx } => {
-            execute_deregister_module(deps, info, module_idx)
-        }
-        ExecuteMsg::AlterModule { module_idx, module } => {
-            execute_alter_module(deps, info, module_idx, &module, ADOType::CW20)
-        }
-        _ => Ok(execute_cw20(deps, env, info, msg.into())?),
-    }
+
+    Ok(Response::default())
 }
 
 fn execute_transfer(
@@ -126,121 +101,10 @@ fn execute_transfer(
     recipient: String,
     amount: Uint128,
 ) -> Result<Response, ContractError> {
-    let mut resp = Response::new();
-    let sender = info.sender.clone();
-    let (payments, events, remainder) = on_funds_transfer(
-        deps.storage,
-        deps.querier,
-        info.sender.to_string(),
-        Funds::Cw20(Cw20Coin {
-            address: env.contract.address.to_string(),
-            amount,
-        }),
-        to_binary(&ExecuteMsg::Transfer {
-            amount,
-            recipient: recipient.clone(),
-        })?,
-    )?;
-    let remaining_amount = match remainder {
-        Funds::Native(..) => amount, //What do we do in the case that the rates returns remaining amount as native funds?
-        Funds::Cw20(coin) => coin.amount,
-    };
-
-    // Filter through payment messages to extract cw20 transfer messages to avoid looping
-    for msg in payments {
-        match msg.msg.clone() {
-            // Transfer messages are CosmosMsg::Wasm type
-            CosmosMsg::Wasm(wasm_msg) => match wasm_msg {
-                WasmMsg::Execute { msg: exec_msg, .. } => {
-                    // If binary deserializes to a Cw20ExecuteMsg check the message type
-                    if let Ok(transfer_msg) = from_binary::<Cw20ExecuteMsg>(&exec_msg) {
-                        match transfer_msg {
-                            // If the message is a transfer message then transfer the tokens from the current message sender to the recipient
-                            Cw20ExecuteMsg::Transfer { recipient, amount } => {
-                                transfer_tokens(
-                                    deps.storage,
-                                    sender.clone(),
-                                    deps.api.addr_validate(&recipient)?,
-                                    amount,
-                                )?;
-                            }
-                            // Otherwise add to messages to be sent in response
-                            _ => {
-                                resp = resp.add_submessage(msg);
-                            }
-                        }
-                    }
-                }
-                // Otherwise add to messages to be sent in response
-                _ => {
-                    resp = resp.add_submessage(msg.clone());
-                }
-            },
-            // Otherwise add to messages to be sent in response
-            _ => {
-                resp = resp.add_submessage(msg);
-            }
-        }
-    }
-
-    // Continue with standard cw20 operation
-    let cw20_resp = execute_cw20_transfer(deps, env, info, recipient, remaining_amount)?;
-    resp = resp.add_attributes(cw20_resp.attributes).add_events(events);
-    Ok(resp)
-}
-
-fn transfer_tokens(
-    storage: &mut dyn Storage,
-    sender: Addr,
-    recipient: Addr,
-    amount: Uint128,
-) -> Result<(), ContractError> {
-    BALANCES.update(
-        storage,
-        &sender,
-        |balance: Option<Uint128>| -> StdResult<_> {
-            Ok(balance.unwrap_or_default().checked_sub(amount)?)
-        },
-    )?;
-    BALANCES.update(
-        storage,
-        &recipient,
-        |balance: Option<Uint128>| -> StdResult<_> { Ok(balance.unwrap_or_default() + amount) },
-    )?;
-    Ok(())
-}
-
-fn execute_burn(
-    deps: DepsMut,
-    env: Env,
-    info: MessageInfo,
-    amount: Uint128,
-) -> Result<Response, ContractError> {
-    Ok(execute_cw20_burn(deps, env, info, amount)?)
-}
-
-fn execute_send(
-    deps: DepsMut,
-    env: Env,
-    info: MessageInfo,
-    contract: String,
-    amount: Uint128,
-    msg: Binary,
-) -> Result<Response, ContractError> {
-    Ok(execute_cw20_send(deps, env, info, contract, amount, msg)?)
-}
-
-fn execute_mint(
-    deps: DepsMut,
-    env: Env,
-    info: MessageInfo,
-    recipient: String,
-    amount: Uint128,
-) -> Result<Response, ContractError> {
-    Ok(execute_cw20_mint(deps, env, info, recipient, amount)?)
+    Ok(Response::default())
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
-    Ok(query_cw20(deps, env, msg.into())?)
+    Ok(AndrCW721Contract::default().query(deps, env, msg.into())?)
 }

--- a/contracts/andromeda_cw721/src/contract.rs
+++ b/contracts/andromeda_cw721/src/contract.rs
@@ -1,8 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_binary, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Empty, Env, MessageInfo, Reply,
-    Response, StdError, Storage, SubMsg,
+    has_coins, to_binary, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Empty, Env, MessageInfo,
+    Reply, Response, StdError, Storage, SubMsg,
 };
 
 use andromeda_protocol::{
@@ -203,6 +203,10 @@ fn check_can_send(
 
     // token purchaser can send
     if let Some(agreement) = token.extension.transfer_agreement.clone() {
+        require(
+            has_coins(&info.funds, &agreement.amount),
+            ContractError::InsufficientFunds {},
+        )?;
         if agreement.purchaser == info.sender {
             return Ok(());
         }

--- a/contracts/andromeda_cw721/src/contract.rs
+++ b/contracts/andromeda_cw721/src/contract.rs
@@ -98,25 +98,25 @@ pub fn execute(
     // Check if the token is archived before any message that may mutate the token
     match &msg {
         ExecuteMsg::TransferNft { token_id, .. } => {
-            is_token_archived(deps.storage, &token_id)?;
+            is_token_archived(deps.storage, token_id)?;
         }
         ExecuteMsg::SendNft { token_id, .. } => {
-            is_token_archived(deps.storage, &token_id)?;
+            is_token_archived(deps.storage, token_id)?;
         }
         ExecuteMsg::Approve { token_id, .. } => {
-            is_token_archived(deps.storage, &token_id)?;
+            is_token_archived(deps.storage, token_id)?;
         }
         ExecuteMsg::Burn { token_id, .. } => {
-            is_token_archived(deps.storage, &token_id)?;
+            is_token_archived(deps.storage, token_id)?;
         }
         ExecuteMsg::Archive { token_id } => {
-            is_token_archived(deps.storage, &token_id)?;
+            is_token_archived(deps.storage, token_id)?;
         }
         ExecuteMsg::TransferAgreement { token_id, .. } => {
-            is_token_archived(deps.storage, &token_id)?;
+            is_token_archived(deps.storage, token_id)?;
         }
         ExecuteMsg::UpdatePricing { token_id, .. } => {
-            is_token_archived(deps.storage, &token_id)?;
+            is_token_archived(deps.storage, token_id)?;
         }
         _ => {}
     }
@@ -156,7 +156,7 @@ pub fn execute(
 
 fn is_token_archived(storage: &dyn Storage, token_id: &str) -> Result<(), ContractError> {
     let contract = AndrCW721Contract::default();
-    let token = contract.tokens.load(storage, &token_id)?;
+    let token = contract.tokens.load(storage, token_id)?;
     require(!token.extension.archived, ContractError::TokenIsArchived {})?;
 
     Ok(())

--- a/contracts/andromeda_cw721/src/lib.rs
+++ b/contracts/andromeda_cw721/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod contract;

--- a/contracts/andromeda_cw721/src/lib.rs
+++ b/contracts/andromeda_cw721/src/lib.rs
@@ -1,1 +1,3 @@
 pub mod contract;
+#[cfg(test)]
+pub mod testing;

--- a/contracts/andromeda_cw721/src/testing/mod.rs
+++ b/contracts/andromeda_cw721/src/testing/mod.rs
@@ -82,7 +82,7 @@ fn test_transfer_nft() {
     );
 
     let info = mock_info(creator.as_str(), &[]);
-    assert!(execute(deps.as_mut(), env.clone(), info, transfer_msg.clone()).is_ok());
+    assert!(execute(deps.as_mut(), env.clone(), info, transfer_msg).is_ok());
 
     let query_msg = QueryMsg::OwnerOf {
         token_id,
@@ -113,7 +113,7 @@ fn test_agreed_transfer_nft() {
         TokenExtension {
             description: None,
             name: String::default(),
-            publisher: creator.clone(),
+            publisher: creator,
             transfer_agreement: Some(TransferAgreement {
                 amount: agreed_amount.clone(),
                 purchaser: purchaser.to_string(),
@@ -142,7 +142,7 @@ fn test_agreed_transfer_nft() {
     );
 
     let info = mock_info(purchaser, &[agreed_amount]);
-    assert!(execute(deps.as_mut(), env.clone(), info, transfer_msg.clone()).is_ok());
+    assert!(execute(deps.as_mut(), env.clone(), info, transfer_msg).is_ok());
 
     let query_msg = QueryMsg::OwnerOf {
         token_id,
@@ -187,7 +187,7 @@ fn test_archive() {
     );
 
     let info = mock_info(creator.as_str(), &[]);
-    assert!(execute(deps.as_mut(), env.clone(), info, msg.clone()).is_ok());
+    assert!(execute(deps.as_mut(), env.clone(), info, msg).is_ok());
 
     let query_msg = QueryMsg::NftInfo { token_id };
     let query_resp = query(deps.as_ref(), env, query_msg).unwrap();
@@ -218,13 +218,11 @@ fn test_archived_check() {
         },
     );
 
-    let msg = ExecuteMsg::Burn {
-        token_id: token_id.clone(),
-    };
+    let msg = ExecuteMsg::Burn { token_id };
 
     let info = mock_info(creator.as_str(), &[]);
     assert_eq!(
-        execute(deps.as_mut(), env.clone(), info, msg.clone()).unwrap_err(),
+        execute(deps.as_mut(), env, info, msg).unwrap_err(),
         ContractError::TokenIsArchived {}
     );
 }
@@ -271,7 +269,7 @@ fn test_transfer_agreement() {
     );
 
     let info = mock_info(creator.as_str(), &[]);
-    assert!(execute(deps.as_mut(), env.clone(), info, msg.clone()).is_ok());
+    assert!(execute(deps.as_mut(), env.clone(), info, msg).is_ok());
 
     let query_msg = QueryMsg::NftInfo { token_id };
     let query_resp = query(deps.as_ref(), env, query_msg).unwrap();
@@ -318,7 +316,7 @@ fn test_update_pricing() {
     );
 
     let info = mock_info(creator.as_str(), &[]);
-    assert!(execute(deps.as_mut(), env.clone(), info, msg.clone()).is_ok());
+    assert!(execute(deps.as_mut(), env.clone(), info, msg).is_ok());
 
     let query_msg = QueryMsg::NftInfo { token_id };
     let query_resp = query(deps.as_ref(), env, query_msg).unwrap();

--- a/contracts/andromeda_cw721/src/testing/mod.rs
+++ b/contracts/andromeda_cw721/src/testing/mod.rs
@@ -1,0 +1,327 @@
+use cosmwasm_std::{Coin, DepsMut, Env};
+
+use crate::contract::*;
+use andromeda_protocol::communication::modules::Module;
+use andromeda_protocol::{
+    cw721::{ExecuteMsg, InstantiateMsg, QueryMsg, TokenExtension, TransferAgreement},
+    error::ContractError,
+};
+use cosmwasm_std::{
+    from_binary,
+    testing::{mock_dependencies, mock_env, mock_info},
+    Addr, Uint128,
+};
+use cw721::{NftInfoResponse, OwnerOfResponse};
+use cw721_base::MintMsg;
+
+const MINTER: &str = "minter";
+const SYMBOL: &str = "TT";
+const NAME: &str = "TestToken";
+
+fn init_setup(deps: DepsMut, env: Env, modules: Option<Vec<Module>>) {
+    let info = mock_info(MINTER, &[]);
+    let inst_msg = InstantiateMsg {
+        name: NAME.to_string(),
+        symbol: SYMBOL.to_string(),
+        minter: MINTER.to_string(),
+        modules,
+    };
+
+    instantiate(deps, env, info, inst_msg).unwrap();
+}
+
+fn mint_token(deps: DepsMut, env: Env, token_id: String, owner: String, extension: TokenExtension) {
+    let info = mock_info(MINTER, &[]);
+    let mint_msg = MintMsg {
+        token_id,
+        owner,
+        token_uri: None,
+        extension,
+    };
+    execute(deps, env, info, ExecuteMsg::Mint(Box::new(mint_msg))).unwrap();
+}
+
+#[test]
+fn test_transfer_nft() {
+    let token_id = String::from("testtoken");
+    let creator = String::from("creator");
+    let mut deps = mock_dependencies(&[]);
+    let env = mock_env();
+    init_setup(deps.as_mut(), env.clone(), None);
+    mint_token(
+        deps.as_mut(),
+        env.clone(),
+        token_id.clone(),
+        creator.clone(),
+        TokenExtension {
+            description: None,
+            name: String::default(),
+            publisher: creator.clone(),
+            transfer_agreement: None,
+            metadata: None,
+            archived: false,
+            pricing: None,
+        },
+    );
+
+    let transfer_msg = ExecuteMsg::TransferNft {
+        recipient: Addr::unchecked("recipient").to_string(),
+        token_id: token_id.clone(),
+    };
+
+    let unauth_info = mock_info("anyone", &[]);
+    assert_eq!(
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            unauth_info,
+            transfer_msg.clone()
+        )
+        .unwrap_err(),
+        ContractError::Unauthorized {}
+    );
+
+    let info = mock_info(creator.as_str(), &[]);
+    assert!(execute(deps.as_mut(), env.clone(), info, transfer_msg.clone()).is_ok());
+
+    let query_msg = QueryMsg::OwnerOf {
+        token_id,
+        include_expired: None,
+    };
+    let query_resp = query(deps.as_ref(), env, query_msg).unwrap();
+    let resp: OwnerOfResponse = from_binary(&query_resp).unwrap();
+    assert_eq!(resp.owner, String::from("recipient"))
+}
+
+#[test]
+fn test_agreed_transfer_nft() {
+    let token_id = String::from("testtoken");
+    let creator = String::from("creator");
+    let mut deps = mock_dependencies(&[]);
+    let env = mock_env();
+    let agreed_amount = Coin {
+        denom: "uluna".to_string(),
+        amount: Uint128::from(100u64),
+    };
+    let purchaser = "purchaser";
+    init_setup(deps.as_mut(), env.clone(), None);
+    mint_token(
+        deps.as_mut(),
+        env.clone(),
+        token_id.clone(),
+        creator.clone(),
+        TokenExtension {
+            description: None,
+            name: String::default(),
+            publisher: creator.clone(),
+            transfer_agreement: Some(TransferAgreement {
+                amount: agreed_amount.clone(),
+                purchaser: purchaser.to_string(),
+            }),
+            metadata: None,
+            archived: false,
+            pricing: None,
+        },
+    );
+
+    let transfer_msg = ExecuteMsg::TransferNft {
+        recipient: Addr::unchecked("recipient").to_string(),
+        token_id: token_id.clone(),
+    };
+
+    let invalid_info = mock_info(purchaser, &[]);
+    assert_eq!(
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            invalid_info,
+            transfer_msg.clone()
+        )
+        .unwrap_err(),
+        ContractError::InsufficientFunds {}
+    );
+
+    let info = mock_info(purchaser, &[agreed_amount]);
+    assert!(execute(deps.as_mut(), env.clone(), info, transfer_msg.clone()).is_ok());
+
+    let query_msg = QueryMsg::OwnerOf {
+        token_id,
+        include_expired: None,
+    };
+    let query_resp = query(deps.as_ref(), env, query_msg).unwrap();
+    let resp: OwnerOfResponse = from_binary(&query_resp).unwrap();
+    assert_eq!(resp.owner, String::from("recipient"))
+}
+
+#[test]
+fn test_archive() {
+    let token_id = String::from("testtoken");
+    let creator = String::from("creator");
+    let mut deps = mock_dependencies(&[]);
+    let env = mock_env();
+    init_setup(deps.as_mut(), env.clone(), None);
+    mint_token(
+        deps.as_mut(),
+        env.clone(),
+        token_id.clone(),
+        creator.clone(),
+        TokenExtension {
+            description: None,
+            name: String::default(),
+            publisher: creator.clone(),
+            transfer_agreement: None,
+            metadata: None,
+            archived: false,
+            pricing: None,
+        },
+    );
+
+    let msg = ExecuteMsg::Archive {
+        token_id: token_id.clone(),
+    };
+
+    let unauth_info = mock_info("anyone", &[]);
+    assert_eq!(
+        execute(deps.as_mut(), env.clone(), unauth_info, msg.clone()).unwrap_err(),
+        ContractError::Unauthorized {}
+    );
+
+    let info = mock_info(creator.as_str(), &[]);
+    assert!(execute(deps.as_mut(), env.clone(), info, msg.clone()).is_ok());
+
+    let query_msg = QueryMsg::NftInfo { token_id };
+    let query_resp = query(deps.as_ref(), env, query_msg).unwrap();
+    let resp: NftInfoResponse<TokenExtension> = from_binary(&query_resp).unwrap();
+    assert!(resp.extension.archived)
+}
+
+#[test]
+fn test_archived_check() {
+    let token_id = String::from("testtoken");
+    let creator = String::from("creator");
+    let mut deps = mock_dependencies(&[]);
+    let env = mock_env();
+    init_setup(deps.as_mut(), env.clone(), None);
+    mint_token(
+        deps.as_mut(),
+        env.clone(),
+        token_id.clone(),
+        creator.clone(),
+        TokenExtension {
+            description: None,
+            name: String::default(),
+            publisher: creator.clone(),
+            transfer_agreement: None,
+            metadata: None,
+            archived: true,
+            pricing: None,
+        },
+    );
+
+    let msg = ExecuteMsg::Burn {
+        token_id: token_id.clone(),
+    };
+
+    let info = mock_info(creator.as_str(), &[]);
+    assert_eq!(
+        execute(deps.as_mut(), env.clone(), info, msg.clone()).unwrap_err(),
+        ContractError::TokenIsArchived {}
+    );
+}
+
+#[test]
+fn test_transfer_agreement() {
+    let token_id = String::from("testtoken");
+    let creator = String::from("creator");
+    let mut deps = mock_dependencies(&[]);
+    let env = mock_env();
+    let agreement = TransferAgreement {
+        purchaser: String::from("purchaser"),
+        amount: Coin {
+            amount: Uint128::from(100u64),
+            denom: "uluna".to_string(),
+        },
+    };
+    init_setup(deps.as_mut(), env.clone(), None);
+    mint_token(
+        deps.as_mut(),
+        env.clone(),
+        token_id.clone(),
+        creator.clone(),
+        TokenExtension {
+            description: None,
+            name: String::default(),
+            publisher: creator.clone(),
+            transfer_agreement: None,
+            metadata: None,
+            archived: false,
+            pricing: None,
+        },
+    );
+
+    let msg = ExecuteMsg::TransferAgreement {
+        token_id: token_id.clone(),
+        agreement: Some(agreement.clone()),
+    };
+
+    let unauth_info = mock_info("anyone", &[]);
+    assert_eq!(
+        execute(deps.as_mut(), env.clone(), unauth_info, msg.clone()).unwrap_err(),
+        ContractError::Unauthorized {}
+    );
+
+    let info = mock_info(creator.as_str(), &[]);
+    assert!(execute(deps.as_mut(), env.clone(), info, msg.clone()).is_ok());
+
+    let query_msg = QueryMsg::NftInfo { token_id };
+    let query_resp = query(deps.as_ref(), env, query_msg).unwrap();
+    let resp: NftInfoResponse<TokenExtension> = from_binary(&query_resp).unwrap();
+    assert_eq!(resp.extension.transfer_agreement, Some(agreement))
+}
+
+#[test]
+fn test_update_pricing() {
+    let token_id = String::from("testtoken");
+    let creator = String::from("creator");
+    let mut deps = mock_dependencies(&[]);
+    let env = mock_env();
+    let price = Coin {
+        amount: Uint128::from(100u64),
+        denom: String::from("uluna"),
+    };
+    init_setup(deps.as_mut(), env.clone(), None);
+    mint_token(
+        deps.as_mut(),
+        env.clone(),
+        token_id.clone(),
+        creator.clone(),
+        TokenExtension {
+            description: None,
+            name: String::default(),
+            publisher: creator.clone(),
+            transfer_agreement: None,
+            metadata: None,
+            archived: false,
+            pricing: None,
+        },
+    );
+
+    let msg = ExecuteMsg::UpdatePricing {
+        token_id: token_id.clone(),
+        price: Some(price.clone()),
+    };
+
+    let unauth_info = mock_info("anyone", &[]);
+    assert_eq!(
+        execute(deps.as_mut(), env.clone(), unauth_info, msg.clone()).unwrap_err(),
+        ContractError::Unauthorized {}
+    );
+
+    let info = mock_info(creator.as_str(), &[]);
+    assert!(execute(deps.as_mut(), env.clone(), info, msg.clone()).is_ok());
+
+    let query_msg = QueryMsg::NftInfo { token_id };
+    let query_resp = query(deps.as_ref(), env, query_msg).unwrap();
+    let resp: NftInfoResponse<TokenExtension> = from_binary(&query_resp).unwrap();
+    assert_eq!(resp.extension.pricing, Some(price))
+}

--- a/packages/andromeda_protocol/Cargo.toml
+++ b/packages/andromeda_protocol/Cargo.toml
@@ -23,4 +23,5 @@ mirror-protocol = "2.1.1"
 cw20 = { version = "0.9.1" }
 cw0 = "0.9.1"
 cw20-base = { version = "0.9.1", features=["library"]}
+cw721-base = { version = "0.9.1", features=["library"]}
 terraswap = {version = "2.4.0"}

--- a/packages/andromeda_protocol/src/common.rs
+++ b/packages/andromeda_protocol/src/common.rs
@@ -1,6 +1,6 @@
 use crate::error::ContractError;
 use crate::modules::{hooks::HookResponse, Module};
-use cosmwasm_std::{DepsMut, Env, MessageInfo};
+use cosmwasm_std::{DepsMut, Env, MessageInfo, Response};
 
 //Redundant? Can maybe use `Modules` struct?
 pub fn generate_instantiate_msgs(
@@ -24,4 +24,10 @@ pub fn unwrap_or_err<T>(val_opt: Option<T>, err: ContractError) -> Result<T, Con
         Some(val) => Ok(val),
         None => Err(err),
     }
+}
+
+pub fn merge_responses(resp_a: Response, resp_b: Response) -> Response {
+    resp_a
+        .add_attributes(resp_b.attributes)
+        .add_submessages(resp_b.messages)
 }

--- a/packages/andromeda_protocol/src/cw721.rs
+++ b/packages/andromeda_protocol/src/cw721.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{attr, BankMsg, Binary, Coin, Event};
+use cosmwasm_std::{attr, BankMsg, Binary, Coin, Event, Uint64};
 use cw721::Expiration;
 use cw721_base::{
     ExecuteMsg as Cw721ExecuteMsg, InstantiateMsg as Cw721InstantiateMsg, MintMsg,
@@ -199,6 +199,16 @@ pub enum ExecuteMsg {
         token_id: String,
         price: Option<Coin>,
     },
+    RegisterModule {
+        module: Module,
+    },
+    DeregisterModule {
+        module_idx: Uint64,
+    },
+    AlterModule {
+        module_idx: Uint64,
+        module: Module,
+    },
 }
 
 impl From<ExecuteMsg> for Cw721ExecuteMsg<TokenExtension> {
@@ -237,7 +247,7 @@ impl From<ExecuteMsg> for Cw721ExecuteMsg<TokenExtension> {
             }
             ExecuteMsg::RevokeAll { operator } => Cw721ExecuteMsg::RevokeAll { operator },
             ExecuteMsg::Mint(msg) => Cw721ExecuteMsg::Mint(*msg),
-            _ => panic!("Invalid CW721 Execute message type"),
+            _ => panic!("Unsupported message"),
         }
     }
 }
@@ -329,7 +339,7 @@ impl From<QueryMsg> for Cw721QueryMsg {
             QueryMsg::AllTokens { start_after, limit } => {
                 Cw721QueryMsg::AllTokens { start_after, limit }
             }
-            _ => panic!("Invalid CW721 Query message type"),
+            _ => panic!("Unsupported message"),
         }
     }
 }

--- a/packages/andromeda_protocol/src/cw721.rs
+++ b/packages/andromeda_protocol/src/cw721.rs
@@ -1,0 +1,232 @@
+use cosmwasm_std::{attr, BankMsg, Coin, Event};
+use cw721_base::{InstantiateMsg as Cw721InstantiateMsg, QueryMsg as Cw721QueryMsg};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    communication::{modules::Module, AndromedaQuery},
+    error::ContractError,
+    modules::common::calculate_fee,
+    modules::Rate,
+};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct InstantiateMsg {
+    /// Name of the NFT contract
+    pub name: String,
+    /// Symbol of the NFT contract
+    pub symbol: String,
+
+    /// The minter is the only one who can create new NFTs.
+    /// This is designed for a base NFT that is controlled by an external program
+    /// or contract. You will likely replace this with custom logic in custom NFTs
+    pub minter: String,
+
+    //The attached Andromeda modules
+    pub modules: Option<Vec<Module>>,
+}
+
+impl From<InstantiateMsg> for Cw721InstantiateMsg {
+    fn from(msg: InstantiateMsg) -> Self {
+        Self {
+            name: msg.name,
+            symbol: msg.symbol,
+            minter: msg.minter,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+/// A struct used to represent an agreed transfer of a token. The `purchaser` may use the `Transfer` message for this token as long as funds are provided equalling the `amount` defined in the agreement.
+pub struct TransferAgreement {
+    /// The amount required for the purchaser to transfer ownership of the token
+    pub amount: Coin,
+    /// The address of the purchaser
+    pub purchaser: String,
+}
+
+impl TransferAgreement {
+    /// Generates a `BankMsg` for the amount defined in the transfer agreement to the provided address
+    pub fn generate_payment(&self, to_address: String) -> BankMsg {
+        BankMsg::Send {
+            to_address,
+            amount: vec![self.amount.clone()],
+        }
+    }
+    /// Generates a `BankMsg` for a given `Rate` to a given address
+    pub fn generate_fee_payment(
+        &self,
+        to_address: String,
+        rate: Rate,
+    ) -> Result<BankMsg, ContractError> {
+        Ok(BankMsg::Send {
+            to_address,
+            amount: vec![calculate_fee(rate, &self.amount)?],
+        })
+    }
+    /// Generates an event related to the agreed transfer of a token
+    pub fn generate_event(self) -> Event {
+        Event::new("agreed_transfer").add_attributes(vec![
+            attr("amount", self.amount.to_string()),
+            attr("purchaser", self.purchaser),
+        ])
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
+/// Enum used to define the type of metadata held by a token
+pub enum MetadataType {
+    Image,
+    Video,
+    Audio,
+    Domain,
+    Json,
+    Other,
+}
+
+impl ToString for MetadataType {
+    fn to_string(&self) -> String {
+        match self {
+            MetadataType::Image => String::from("Image"),
+            MetadataType::Video => String::from("Video"),
+            MetadataType::Audio => String::from("Audio"),
+            MetadataType::Domain => String::from("Domain"),
+            MetadataType::Json => String::from("Json"),
+            MetadataType::Other => String::from("Other"),
+        }
+    }
+}
+// [TOK-02] Add approval function should have been here but maybe was removed or altered in alter commits.
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct MetadataAttribute {
+    /// The key for the attribute
+    pub key: String,
+    /// The value for the attribute
+    pub value: String,
+    /// The string used to display the attribute, if none is provided the `key` field can be used
+    pub display_label: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct TokenMetadata {
+    /// The metadata type
+    pub data_type: MetadataType,
+    /// A URL to the token's source
+    pub external_url: Option<String>,
+    /// A URL to any off-chain data relating to the token, the response from this URL should match the defined `data_type` of the token
+    pub data_url: Option<String>,
+    /// On chain attributes related to the token (basic key/value)
+    pub attributes: Option<Vec<MetadataAttribute>>,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct TokenExtension {
+    /// The name of the token
+    pub name: String,
+    /// The original publisher of the token (immutable)
+    pub publisher: String,
+    /// An optional description of the token
+    pub description: Option<String>,
+    /// The transfer agreement of the token (if it exists)
+    pub transfer_agreement: Option<TransferAgreement>,
+    /// The metadata of the token (if it exists)
+    pub metadata: Option<TokenMetadata>,
+    /// Whether the token is archived or not
+    pub archived: bool,
+    /// The current price listing for the token
+    pub pricing: Option<Coin>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    AndrQuery(AndromedaQuery),
+    /// Owner of the given token by ID
+    OwnerOf {
+        token_id: String,
+        include_expired: Option<bool>,
+    },
+    /// Approvals for a given address (paginated)
+    ApprovedForAll {
+        owner: String,
+        include_expired: Option<bool>,
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+    /// Amount of tokens minted by the contract
+    NumTokens {},
+    /// The data of a token
+    NftInfo {
+        token_id: String,
+    },
+    /// The data of a token and any approvals assigned to it
+    AllNftInfo {
+        token_id: String,
+        include_expired: Option<bool>,
+    },
+    /// All tokens minted by the contract owned by a given address (paginated)
+    Tokens {
+        owner: String,
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+    /// All tokens minted by the contract (paginated)
+    AllTokens {
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+    /// Info of any modules assigned to the contract
+    ModuleInfo {},
+    /// The current config of the contract
+    ContractInfo {},
+}
+
+impl From<QueryMsg> for Cw721QueryMsg {
+    fn from(msg: QueryMsg) -> Self {
+        match msg {
+            QueryMsg::OwnerOf {
+                token_id,
+                include_expired,
+            } => Cw721QueryMsg::OwnerOf {
+                token_id,
+                include_expired,
+            },
+            QueryMsg::ApprovedForAll {
+                owner,
+                include_expired,
+                start_after,
+                limit,
+            } => Cw721QueryMsg::ApprovedForAll {
+                owner,
+                include_expired,
+                start_after,
+                limit,
+            },
+            QueryMsg::NumTokens {} => Cw721QueryMsg::NumTokens {},
+            QueryMsg::ContractInfo {} => Cw721QueryMsg::ContractInfo {},
+            QueryMsg::NftInfo { token_id } => Cw721QueryMsg::NftInfo { token_id },
+            QueryMsg::AllNftInfo {
+                token_id,
+                include_expired,
+            } => Cw721QueryMsg::AllNftInfo {
+                token_id,
+                include_expired,
+            },
+            QueryMsg::Tokens {
+                owner,
+                start_after,
+                limit,
+            } => Cw721QueryMsg::Tokens {
+                owner,
+                start_after,
+                limit,
+            },
+            QueryMsg::AllTokens { start_after, limit } => {
+                Cw721QueryMsg::AllTokens { start_after, limit }
+            }
+            _ => panic!("Invalid CW721 query message type"),
+        }
+    }
+}

--- a/packages/andromeda_protocol/src/error.rs
+++ b/packages/andromeda_protocol/src/error.rs
@@ -1,5 +1,6 @@
 use cosmwasm_std::StdError;
 use cw20_base::ContractError as Cw20ContractError;
+use cw721_base::ContractError as Cw721ContractError;
 use std::convert::From;
 use std::string::FromUtf8Error;
 use thiserror::Error;
@@ -149,6 +150,9 @@ pub enum ContractError {
 
     #[error("ModuleDoesNotExist")]
     ModuleDoesNotExist {},
+
+    #[error("token_id already claimed")]
+    Claimed {},
 }
 
 impl From<Cw20ContractError> for ContractError {
@@ -164,6 +168,17 @@ impl From<Cw20ContractError> for ContractError {
             Cw20ContractError::InvalidZeroAmount {} => ContractError::InvalidZeroAmount {},
             Cw20ContractError::InvalidXmlPreamble {} => ContractError::InvalidXmlPreamble {},
             Cw20ContractError::CannotSetOwnAccount {} => ContractError::CannotSetOwnAccount {},
+        }
+    }
+}
+
+impl From<Cw721ContractError> for ContractError {
+    fn from(err: Cw721ContractError) -> Self {
+        match err {
+            Cw721ContractError::Std(std) => ContractError::Std(std),
+            Cw721ContractError::Expired {} => ContractError::Expired {},
+            Cw721ContractError::Unauthorized {} => ContractError::Unauthorized {},
+            Cw721ContractError::Claimed {} => ContractError::Claimed {},
         }
     }
 }

--- a/packages/andromeda_protocol/src/lib.rs
+++ b/packages/andromeda_protocol/src/lib.rs
@@ -5,6 +5,7 @@ pub mod anchor;
 pub mod common;
 pub mod communication;
 pub mod cw20;
+pub mod cw721;
 pub mod error;
 pub mod factory;
 pub mod mirror_wrapped_cdp;


### PR DESCRIPTION
# Motivation
Creation of a CW721 compliant token contract that implements both the required ADO messages and the use of our module hooks structures.

# Implementation
Created a new `andromeda_cw721` contract that builds upon the `cw721-base` contract provided by `cw-nfts`.  Hooks were implemented in a similar fashion to the `andromeda_cw20` contract. The standard `transfer_nft` message had to be recreated as it is not possible to override the `Cw721Contract` implementation of `check_can_send` so a custom method had to be created. 

# Testing

## Unit/Integration tests
Unit tests were written for each message type that was altered or added from the `cw721-base` contract inside `src/testing/mod.rs`.

## On-chain tests
On-chain tests will be performed as part of a larger testing scope.

# Future work
Write integration tests for module employment.
