### PR TITLE
CU-1u5yywn | Add AndromedaMsg support to Factory contract 

### DIFF
--- a/packages/andromeda_protocol/src/factory.rs
+++ b/packages/andromeda_protocol/src/factory.rs
@@ -1,4 +1,7 @@
-use crate::{communication::AndromedaQuery, modules::ModuleDefinition};
+use crate::{
+    communication::{AndromedaMsg, AndromedaQuery},
+    modules::ModuleDefinition,
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -8,6 +11,7 @@ pub struct InstantiateMsg {}
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
+    AndrReceive(AndromedaMsg),
     /// Create new token
     Create {
         name: String,
@@ -23,13 +27,6 @@ pub enum ExecuteMsg {
         symbol: String,
         new_address: String,
     },
-    /// Update current contract owner
-    UpdateOwner {
-        address: String,
-    },
-    UpdateOperator {
-        operators: Vec<String>,
-    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -43,11 +40,6 @@ pub enum QueryMsg {
     /// All code IDs for Andromeda contracts
     CodeId {
         key: String,
-    },
-    /// The current contract owner
-    ContractOwner {},
-    IsOperator {
-        address: String,
     },
 }
 


### PR DESCRIPTION
# Motivation
We want all of our contracts to support this standard set of messages for communication.

# Implementation
I followed the standard implementation of `AndromdaMsg` support. I also removed redundant messages and added a unit test for `AndromedaQuery::Get` and this contract uses a non-standard implementation for it.

# Testing

## Unit/Integration tests
None for the `AndromedaMsg` part as that is very standard, but I did add one for `AndromedaQuery::Get` as mentioned in the previous section.

## On-chain tests
No, but this behaviour has been tested in other contracts successfully. 

# Future work
n/a