### PR TITLE
Add integration test for CW721 modules

### DIFF
--- a/contracts/andromeda_cw721/src/contract.rs
+++ b/contracts/andromeda_cw721/src/contract.rs
@@ -228,7 +228,9 @@ fn execute_transfer(
         .tokens
         .save(deps.storage, token_id.as_str(), &token)?;
 
-    Ok(resp)
+    Ok(resp
+        .add_attribute("action", "transfer")
+        .add_attribute("recipient", recipient))
 }
 
 fn check_can_send(

--- a/contracts/andromeda_cw721/src/testing/mod.rs
+++ b/contracts/andromeda_cw721/src/testing/mod.rs
@@ -1,10 +1,18 @@
-use cosmwasm_std::{attr, Coin, DepsMut, Env, Response};
+use cosmwasm_std::{
+    attr, coins, to_binary, BankMsg, Coin, CosmosMsg, DepsMut, Env, Event, Response, StdError,
+    SubMsg, WasmMsg,
+};
 
 use crate::contract::*;
-use andromeda_protocol::communication::modules::Module;
 use andromeda_protocol::{
+    communication::modules::{InstantiateType, Module, ModuleType},
     cw721::{ExecuteMsg, InstantiateMsg, QueryMsg, TokenExtension, TransferAgreement},
     error::ContractError,
+    receipt::{ExecuteMsg as ReceiptExecuteMsg, Receipt},
+    testing::mock_querier::{
+        mock_dependencies_custom, MOCK_ADDRESSLIST_CONTRACT, MOCK_RATES_CONTRACT,
+        MOCK_RECEIPT_CONTRACT,
+    },
 };
 use cosmwasm_std::{
     from_binary,
@@ -379,4 +387,110 @@ fn test_update_pricing() {
     let query_resp = query(deps.as_ref(), env, query_msg).unwrap();
     let resp: NftInfoResponse<TokenExtension> = from_binary(&query_resp).unwrap();
     assert_eq!(resp.extension.pricing, Some(price))
+}
+
+#[test]
+fn test_modules() {
+    // TODO: Test InstantiateType::New() when Fetch contract works.
+    let modules: Vec<Module> = vec![
+        Module {
+            module_type: ModuleType::Receipt,
+            instantiate: InstantiateType::Address(MOCK_RECEIPT_CONTRACT.into()),
+        },
+        Module {
+            module_type: ModuleType::Rates,
+            instantiate: InstantiateType::Address(MOCK_RATES_CONTRACT.into()),
+        },
+        Module {
+            module_type: ModuleType::AddressList,
+            instantiate: InstantiateType::Address(MOCK_ADDRESSLIST_CONTRACT.into()),
+        },
+    ];
+
+    let mut deps = mock_dependencies_custom(&[]);
+
+    let token_id = String::from("testtoken");
+    let creator = String::from("creator");
+    let env = mock_env();
+    let agreement = TransferAgreement {
+        purchaser: String::from("purchaser"),
+        amount: Coin {
+            amount: Uint128::from(100u64),
+            denom: "uluna".to_string(),
+        },
+    };
+    init_setup(deps.as_mut(), env.clone(), Some(modules));
+    mint_token(
+        deps.as_mut(),
+        env.clone(),
+        token_id.clone(),
+        creator.clone(),
+        TokenExtension {
+            description: None,
+            name: String::default(),
+            publisher: creator.clone(),
+            transfer_agreement: None,
+            metadata: None,
+            archived: false,
+            pricing: None,
+        },
+    );
+
+    let msg = ExecuteMsg::TransferAgreement {
+        token_id: token_id.clone(),
+        agreement: Some(agreement.clone()),
+    };
+
+    let not_whitelisted_info = mock_info("not_whitelisted", &[]);
+    let res = execute(deps.as_mut(), mock_env(), not_whitelisted_info, msg.clone());
+    assert_eq!(
+        ContractError::Std(StdError::generic_err(
+            "Querier contract error: InvalidAddress"
+        )),
+        res.unwrap_err()
+    );
+
+    let info = mock_info("creator", &[]);
+    let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    let purchaser = mock_info("purchaser", &coins(100u128, "uluna"));
+
+    let msg = ExecuteMsg::TransferNft {
+        token_id,
+        recipient: "purchaser".into(),
+    };
+
+    let res = execute(deps.as_mut(), mock_env(), purchaser, msg).unwrap();
+
+    let receipt_msg: SubMsg = SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
+        contract_addr: MOCK_RECEIPT_CONTRACT.to_string(),
+        msg: to_binary(&ReceiptExecuteMsg::StoreReceipt {
+            receipt: Receipt {
+                events: vec![Event::new("Royalty")],
+            },
+        })
+        .unwrap(),
+        funds: vec![],
+    }));
+
+    let sub_msgs: Vec<SubMsg> = vec![
+        SubMsg::new(CosmosMsg::Bank(BankMsg::Send {
+            to_address: "rates_recipient".to_string(),
+            amount: coins(10u128, "uluna"),
+        })),
+        receipt_msg,
+        SubMsg::new(CosmosMsg::Bank(BankMsg::Send {
+            to_address: "creator".to_string(),
+            amount: coins(90u128, "uluna"),
+        })),
+    ];
+
+    assert_eq!(
+        Response::new()
+            .add_attribute("action", "transfer")
+            .add_attribute("recipient", "purchaser")
+            .add_submessages(sub_msgs)
+            .add_event(Event::new("Royalty")),
+        res
+    );
 }

--- a/contracts/andromeda_cw721/src/testing/mod.rs
+++ b/contracts/andromeda_cw721/src/testing/mod.rs
@@ -422,13 +422,13 @@ fn test_modules() {
     init_setup(deps.as_mut(), env.clone(), Some(modules));
     mint_token(
         deps.as_mut(),
-        env.clone(),
+        env,
         token_id.clone(),
         creator.clone(),
         TokenExtension {
             description: None,
             name: String::default(),
-            publisher: creator.clone(),
+            publisher: creator,
             transfer_agreement: None,
             metadata: None,
             archived: false,
@@ -438,7 +438,7 @@ fn test_modules() {
 
     let msg = ExecuteMsg::TransferAgreement {
         token_id: token_id.clone(),
-        agreement: Some(agreement.clone()),
+        agreement: Some(agreement),
     };
 
     let not_whitelisted_info = mock_info("not_whitelisted", &[]);

--- a/packages/andromeda_protocol/src/testing/mock_querier.rs
+++ b/packages/andromeda_protocol/src/testing/mock_querier.rs
@@ -199,9 +199,9 @@ impl WasmMockQuerier {
         match from_binary(msg).unwrap() {
             AddressListQueryMsg::AndrHook(hook_msg) => match hook_msg {
                 AndromedaHook::OnExecute { sender, payload: _ } => {
-                    // Only the "sender" is whitelisted.
+                    let whitelisted_addresses = ["sender", "minter", "purchaser", "creator"];
                     let response: Response = Response::default();
-                    if sender == "sender" {
+                    if whitelisted_addresses.contains(&sender.as_str()) {
                         SystemResult::Ok(ContractResult::Ok(to_binary(&response).unwrap()))
                     } else {
                         SystemResult::Ok(ContractResult::Err("InvalidAddress".to_string()))


### PR DESCRIPTION
# Motivation
Testing is necessary.

# Implementation
I took the same scenario as the integration test for the cw20 modules and applied it to a transfer agreement with a cw721 token.

# Testing

## Unit/Integration tests
This PR is the test.

## On-chain tests
n/a

# Future work
Add tests for more combinations of modules as they get added.