### PR TITLE
Improve Anchor ADO

### DIFF
--- a/contracts/andromeda_anchor/src/contract.rs
+++ b/contracts/andromeda_anchor/src/contract.rs
@@ -1,5 +1,5 @@
 use crate::state::{
-    Config, Position, CONFIG, KEY_POSITION_IDX, POSITION, PREV_AUST_BALANCE, TEMP_BALANCE,
+    Config, Position, CONFIG, POSITION, PREV_AUST_BALANCE, PREV_UUSD_BALANCE, RECIPIENT_ADDR,
 };
 use andromeda_protocol::{
     anchor::{ExecuteMsg, InstantiateMsg, QueryMsg},
@@ -20,6 +20,8 @@ use terraswap::querier::{query_balance, query_token_balance};
 use andromeda_protocol::anchor::{AnchorMarketMsg, ConfigResponse, YourselfMsg};
 
 const UUSD_DENOM: &str = "uusd";
+const DEPOSIT_ID: u64 = 1;
+const WITHDRAW_ID: u64 = 2;
 
 #[entry_point]
 pub fn instantiate(
@@ -33,9 +35,8 @@ pub fn instantiate(
         aust_token: deps.api.addr_canonicalize(&msg.aust_token)?,
     };
     CONFIG.save(deps.storage, &config)?;
-    KEY_POSITION_IDX.save(deps.storage, &Uint128::from(1u128))?;
     PREV_AUST_BALANCE.save(deps.storage, &Uint128::zero())?;
-    TEMP_BALANCE.save(deps.storage, &Uint128::zero())?;
+    PREV_UUSD_BALANCE.save(deps.storage, &Uint128::zero())?;
     CONTRACT_OWNER.save(deps.storage, &info.sender)?;
     Ok(Response::new().add_attributes(vec![attr("action", "instantiate"), attr("type", "anchor")]))
 }
@@ -50,16 +51,10 @@ pub fn execute(
     match msg {
         ExecuteMsg::AndrReceive(msg) => execute_andr_receive(deps, env, info, msg),
         ExecuteMsg::Deposit { recipient } => execute_deposit(deps, env, info, recipient),
-        ExecuteMsg::Withdraw { position_idx } => withdraw(deps, env, info, position_idx),
-        ExecuteMsg::Yourself { yourself_msg } => {
-            require(
-                info.sender == env.contract.address,
-                ContractError::Unauthorized {},
-            )?;
-            match yourself_msg {
-                YourselfMsg::TransferUst { receiver } => transfer_ust(deps, env, receiver),
-            }
-        }
+        ExecuteMsg::Withdraw {
+            percent,
+            recipient_addr,
+        } => withdraw(deps, env, info, percent, recipient_addr),
     }
 }
 
@@ -91,16 +86,13 @@ pub fn execute_deposit(
     info: MessageInfo,
     recipient: Option<Recipient>,
 ) -> Result<Response, ContractError> {
+    require(info.funds.len() == 1, ContractError::MoreThanOneCoin {})?;
+
     let config = CONFIG.load(deps.storage)?;
-    let depositor = match recipient {
+    let recipient = match recipient {
         Some(recipient) => recipient,
         None => Recipient::Addr(info.sender.to_string()),
     };
-
-    require(
-        info.funds.len() <= 1usize,
-        ContractError::MoreThanOneCoin {},
-    )?;
 
     let payment = info
         .funds
@@ -110,21 +102,21 @@ pub fn execute_deposit(
             StdError::generic_err(format!("No {} assets are provided to deposit", UUSD_DENOM))
         })?;
     //create position
-    let position_idx = KEY_POSITION_IDX.load(deps.storage)?;
     let aust_balance = query_token_balance(
         &deps.querier,
         deps.api.addr_humanize(&config.aust_token)?,
         env.contract.address,
     )?;
+    let recipient_addr = recipient.get_addr();
     PREV_AUST_BALANCE.save(deps.storage, &aust_balance)?;
+    RECIPIENT_ADDR.save(deps.storage, &recipient_addr)?;
     let payment_amount = payment.amount;
 
     POSITION.save(
         deps.storage,
-        &position_idx.u128().to_be_bytes(),
+        &recipient_addr,
         &Position {
-            idx: Default::default(),
-            owner: depositor,
+            owner: recipient,
             deposit_amount: payment_amount,
             aust_amount: Uint128::zero(),
         },
@@ -138,7 +130,7 @@ pub fn execute_deposit(
                 msg: to_binary(&AnchorMarketMsg::DepositStable {})?,
                 funds: vec![payment.clone()],
             }),
-            1u64,
+            DEPOSIT_ID,
         ))
         .add_attributes(vec![
             attr("action", "deposit"),
@@ -150,81 +142,57 @@ pub fn withdraw(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    position_idx: Uint128,
+    percent: Option<Uint128>,
+    recipient_addr: String,
 ) -> Result<Response, ContractError> {
     let config = CONFIG.load(deps.storage)?;
-    let position = POSITION.load(deps.storage, &position_idx.u128().to_be_bytes())?;
+    let mut position = POSITION.load(deps.storage, &recipient_addr)?;
 
-    require(
-        is_operator(deps.storage, info.sender.as_str())?
-            || is_contract_owner(deps.storage, info.sender.as_str())?,
-        ContractError::Unauthorized {},
-    )?;
+    let authorized = recipient_addr == info.sender
+        || is_operator(deps.storage, info.sender.as_str())?
+        || is_contract_owner(deps.storage, info.sender.as_str())?;
+
+    require(authorized, ContractError::Unauthorized {})?;
 
     let contract_balance = query_balance(
         &deps.querier,
         env.contract.address.clone(),
         UUSD_DENOM.to_owned(),
     )?;
-    TEMP_BALANCE.save(deps.storage, &contract_balance)?;
-
-    POSITION.remove(deps.storage, &position_idx.u128().to_be_bytes());
+    PREV_UUSD_BALANCE.save(deps.storage, &contract_balance)?;
+    let amount_to_redeem = match percent {
+        None => position.aust_amount,
+        Some(percent) => {
+            require(percent <= 100u128.into(), ContractError::InvalidRate {})?;
+            position.aust_amount.multiply_ratio(percent, 100u128)
+        }
+    };
+    position.aust_amount = position.aust_amount.checked_sub(amount_to_redeem)?;
+    POSITION.save(deps.storage, &recipient_addr, &position)?;
 
     Ok(Response::new()
-        .add_messages(vec![
+        .add_submessage(SubMsg::reply_on_success(
             CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: deps.api.addr_humanize(&config.aust_token)?.to_string(),
                 msg: to_binary(&Cw20ExecuteMsg::Send {
                     contract: deps.api.addr_humanize(&config.anchor_market)?.to_string(),
-                    amount: position.aust_amount,
+                    amount: amount_to_redeem,
                     msg: to_binary(&AnchorMarketMsg::RedeemStable {})?,
                 })?,
                 funds: vec![],
             }),
-            //send UST
-            CosmosMsg::Wasm(WasmMsg::Execute {
-                contract_addr: env.contract.address.to_string(),
-                msg: to_binary(&ExecuteMsg::Yourself {
-                    yourself_msg: YourselfMsg::TransferUst {
-                        receiver: position.owner,
-                    },
-                })?,
-                funds: vec![],
-            }),
-        ])
+            WITHDRAW_ID,
+        ))
         .add_attributes(vec![
             attr("action", "withdraw"),
-            attr("position_idx", position_idx.to_string()),
+            attr("recipient_addr", recipient_addr),
         ]))
 }
 
-pub fn transfer_ust(
-    deps: DepsMut,
-    env: Env,
-    receiver: Recipient,
-) -> Result<Response, ContractError> {
-    let current_balance =
-        query_balance(&deps.querier, env.contract.address, UUSD_DENOM.to_owned())?;
-    let prev_balance = TEMP_BALANCE.load(deps.storage)?;
-    let transfer_amount = current_balance - prev_balance;
-    let mut msgs = vec![];
-    if transfer_amount > Uint128::zero() {
-        msgs.push(
-            receiver
-                .generate_msg_native(&deps.as_ref(), coins(transfer_amount.u128(), UUSD_DENOM))?,
-        );
-    }
-    Ok(Response::new().add_submessages(msgs).add_attributes(vec![
-        attr("action", "withdraw"),
-        attr("receiver", receiver.get_addr()),
-        attr("amount", transfer_amount.to_string()),
-    ]))
-}
-
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> StdResult<Response> {
+pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractError> {
     match msg.id {
-        1u64 => {
+        DEPOSIT_ID => {
             // stores aUST amount to position
             let config = CONFIG.load(deps.storage)?;
             let aust_balance = query_token_balance(
@@ -236,21 +204,45 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> StdResult<Response> {
             let prev_aust_balance = PREV_AUST_BALANCE.load(deps.storage)?;
             let new_aust_balance = aust_balance.checked_sub(prev_aust_balance)?;
             if new_aust_balance <= Uint128::from(1u128) {
-                return Err(StdError::generic_err("no minted aUST token"));
+                return Err(ContractError::Std(StdError::generic_err(
+                    "no minted aUST token",
+                )));
             }
-            let position_idx = KEY_POSITION_IDX.load(deps.storage)?;
-            let mut position = POSITION.load(deps.storage, &position_idx.u128().to_be_bytes())?;
+            let recipient_addr = RECIPIENT_ADDR.load(deps.storage)?;
+            let mut position = POSITION.load(deps.storage, &recipient_addr)?;
             position.aust_amount = new_aust_balance;
-            POSITION.save(deps.storage, &position_idx.u128().to_be_bytes(), &position)?;
-            KEY_POSITION_IDX.save(deps.storage, &(position_idx + Uint128::from(1u128)))?;
+            POSITION.save(deps.storage, &recipient_addr, &position)?;
             Ok(Response::new().add_attributes(vec![
                 attr("action", "reply"),
-                attr("position_idx", position_idx.clone().to_string()),
+                attr("recipient_addr", recipient_addr.clone().to_string()),
                 attr("aust_amount", new_aust_balance.to_string()),
             ]))
         }
-        _ => Err(StdError::generic_err("invalid reply id")),
+        WITHDRAW_ID => withdraw_ust(deps, env),
+        _ => Err(ContractError::InvalidReplyId {}),
     }
+}
+
+fn withdraw_ust(deps: DepsMut, env: Env) -> Result<Response, ContractError> {
+    let current_balance =
+        query_balance(&deps.querier, env.contract.address, UUSD_DENOM.to_owned())?;
+    let prev_balance = PREV_UUSD_BALANCE.load(deps.storage)?;
+    let transfer_amount = current_balance - prev_balance;
+
+    let recipient_addr = RECIPIENT_ADDR.load(deps.storage)?;
+    let recipient = POSITION.load(deps.storage, &recipient_addr)?.owner;
+    let mut msgs = vec![];
+    if transfer_amount > Uint128::zero() {
+        msgs.push(
+            recipient
+                .generate_msg_native(&deps.as_ref(), coins(transfer_amount.u128(), UUSD_DENOM))?,
+        );
+    }
+    Ok(Response::new().add_submessages(msgs).add_attributes(vec![
+        attr("action", "withdraw"),
+        attr("recipient", recipient_addr),
+        attr("amount", transfer_amount),
+    ]))
 }
 
 #[entry_point]

--- a/contracts/andromeda_anchor/src/contract.rs
+++ b/contracts/andromeda_anchor/src/contract.rs
@@ -161,11 +161,8 @@ pub fn execute_withdraw(
 
     require(authorized, ContractError::Unauthorized {})?;
 
-    let contract_balance = query_balance(
-        &deps.querier,
-        env.contract.address,
-        UUSD_DENOM.to_owned(),
-    )?;
+    let contract_balance =
+        query_balance(&deps.querier, env.contract.address, UUSD_DENOM.to_owned())?;
     PREV_UUSD_BALANCE.save(deps.storage, &contract_balance)?;
     RECIPIENT_ADDR.save(deps.storage, &recipient_addr)?;
     let amount_to_redeem = match percent {

--- a/contracts/andromeda_anchor/src/contract.rs
+++ b/contracts/andromeda_anchor/src/contract.rs
@@ -163,7 +163,7 @@ pub fn execute_withdraw(
 
     let contract_balance = query_balance(
         &deps.querier,
-        env.contract.address.clone(),
+        env.contract.address,
         UUSD_DENOM.to_owned(),
     )?;
     PREV_UUSD_BALANCE.save(deps.storage, &contract_balance)?;
@@ -230,7 +230,7 @@ fn reply_update_position(deps: DepsMut, env: Env) -> Result<Response, ContractEr
     POSITION.save(deps.storage, &recipient_addr, &position)?;
     Ok(Response::new().add_attributes(vec![
         attr("action", "reply_update_position"),
-        attr("recipient_addr", recipient_addr.clone().to_string()),
+        attr("recipient_addr", recipient_addr.clone()),
         attr("aust_amount", new_aust_balance.to_string()),
     ]))
 }

--- a/contracts/andromeda_anchor/src/state.rs
+++ b/contracts/andromeda_anchor/src/state.rs
@@ -5,10 +5,10 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 pub const CONFIG: Item<Config> = Item::new("config");
-pub const KEY_POSITION_IDX: Item<Uint128> = Item::new("position_idx");
-pub const POSITION: Map<&[u8], Position> = Map::new("position");
+pub const POSITION: Map<&str, Position> = Map::new("position");
 pub const PREV_AUST_BALANCE: Item<Uint128> = Item::new("prev_aust_balance");
-pub const TEMP_BALANCE: Item<Uint128> = Item::new("temp_balance");
+pub const PREV_UUSD_BALANCE: Item<Uint128> = Item::new("prev_uusd_balance");
+pub const RECIPIENT_ADDR: Item<String> = Item::new("recipient_addr");
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
@@ -18,7 +18,6 @@ pub struct Config {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Position {
-    pub idx: Uint128,
     pub owner: Recipient,
     pub deposit_amount: Uint128,
     pub aust_amount: Uint128,

--- a/contracts/andromeda_anchor/src/state.rs
+++ b/contracts/andromeda_anchor/src/state.rs
@@ -19,6 +19,5 @@ pub struct Config {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Position {
     pub owner: Recipient,
-    pub deposit_amount: Uint128,
     pub aust_amount: Uint128,
 }

--- a/contracts/andromeda_anchor/src/state.rs
+++ b/contracts/andromeda_anchor/src/state.rs
@@ -12,9 +12,8 @@ pub const TEMP_BALANCE: Item<Uint128> = Item::new("temp_balance");
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
-    pub anchor_mint: CanonicalAddr,
-    pub anchor_token: CanonicalAddr,
-    pub stable_denom: String,
+    pub anchor_market: CanonicalAddr,
+    pub aust_token: CanonicalAddr,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/andromeda_anchor/src/state.rs
+++ b/contracts/andromeda_anchor/src/state.rs
@@ -18,6 +18,6 @@ pub struct Config {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Position {
-    pub owner: Recipient,
+    pub recipient: Recipient,
     pub aust_amount: Uint128,
 }

--- a/contracts/andromeda_anchor/src/testing/mock_querier.rs
+++ b/contracts/andromeda_anchor/src/testing/mock_querier.rs
@@ -7,8 +7,8 @@ use serde::Deserialize;
 use terra_cosmwasm::TerraQueryWrapper;
 
 pub struct WasmMockQuerier {
-    base: MockQuerier<TerraQueryWrapper>,
-    token_balance: Uint128,
+    pub base: MockQuerier<TerraQueryWrapper>,
+    pub token_balance: Uint128,
 }
 
 pub fn mock_dependencies_custom(

--- a/contracts/andromeda_anchor/src/testing/tests.rs
+++ b/contracts/andromeda_anchor/src/testing/tests.rs
@@ -241,7 +241,7 @@ fn test_deposit_existing_position() {
     );
 
     // Deposit again.
-    let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
+    let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     // The amount of aUST has now doubled.
     deps.querier.token_balance = (aust_amount * 2).into();
@@ -279,7 +279,7 @@ fn test_deposit_other_recipient() {
             amount: Uint128::from(amount),
         }],
     );
-    let _res = execute(deps.as_mut(), mock_env(), info.clone(), msg.clone()).unwrap();
+    let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     // Suppose exchange rate is 1 uusd = 0.5 aUST.
     let aust_amount = amount / 2;
@@ -293,7 +293,7 @@ fn test_deposit_other_recipient() {
         }),
     };
 
-    let res = reply(deps.as_mut(), mock_env(), my_reply.clone()).unwrap();
+    let res = reply(deps.as_mut(), mock_env(), my_reply).unwrap();
 
     assert_eq!(
         Response::new().add_attributes(vec![
@@ -359,7 +359,7 @@ fn test_withdraw_recipient_sender() {
     };
     let amount = 1000000u128;
     let info = mock_info("addr0000", &[]);
-    let _res = instantiate(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
+    let _res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     let recipient = "recipient";
 

--- a/contracts/andromeda_anchor/src/testing/tests.rs
+++ b/contracts/andromeda_anchor/src/testing/tests.rs
@@ -19,9 +19,8 @@ fn test_instantiate() {
     let owner = "owner";
     let info = mock_info(owner, &[]);
     let msg = InstantiateMsg {
-        anchor_token: "anchor_token".to_string(),
-        anchor_mint: "anchor_mint".to_string(),
-        stable_denom: "uusd".to_string(),
+        aust_token: "aust_token".to_string(),
+        anchor_market: "anchor_market".to_string(),
     };
     let res = instantiate(deps.as_mut(), env, info, msg.clone()).unwrap();
 
@@ -31,28 +30,26 @@ fn test_instantiate() {
     let config = CONFIG.load(deps.as_ref().storage).unwrap();
 
     assert_eq!(
-        msg.anchor_token,
+        msg.aust_token,
         deps.api
-            .addr_humanize(&config.anchor_token)
+            .addr_humanize(&config.aust_token)
             .unwrap()
             .to_string()
     );
     assert_eq!(
-        msg.anchor_mint,
+        msg.anchor_market,
         deps.api
-            .addr_humanize(&config.anchor_mint)
+            .addr_humanize(&config.anchor_market)
             .unwrap()
             .to_string()
     );
-    assert_eq!(msg.stable_denom, config.stable_denom);
 }
 #[test]
 fn test_deposit() {
     let mut deps = mock_dependencies_custom(&[]);
     let msg = InstantiateMsg {
-        anchor_token: "aust_token".to_string(),
-        anchor_mint: "anchor_mint".to_string(),
-        stable_denom: "uusd".to_string(),
+        aust_token: "aust_token".to_string(),
+        anchor_market: "anchor_market".to_string(),
     };
     let info = mock_info("addr0000", &[]);
     let _res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -70,7 +67,7 @@ fn test_deposit() {
     let expected_res = Response::new()
         .add_submessage(SubMsg::reply_on_success(
             CosmosMsg::Wasm(WasmMsg::Execute {
-                contract_addr: "anchor_mint".to_string(),
+                contract_addr: "anchor_market".to_string(),
                 msg: to_binary(&AnchorMarketMsg::DepositStable {}).unwrap(),
                 funds: vec![coin(1000000u128, "uusd")],
             }),
@@ -87,9 +84,8 @@ fn test_deposit() {
 fn test_withdraw_addr_recipient() {
     let mut deps = mock_dependencies_custom(&[]);
     let msg = InstantiateMsg {
-        anchor_token: "aust_token".to_string(),
-        anchor_mint: "anchor_mint".to_string(),
-        stable_denom: "uusd".to_string(),
+        aust_token: "aust_token".to_string(),
+        anchor_market: "anchor_market".to_string(),
     };
     let info = mock_info("addr0000", &[]);
     let _res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -122,7 +118,7 @@ fn test_withdraw_addr_recipient() {
             CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: "aust_token".to_string(),
                 msg: to_binary(&Cw20ExecuteMsg::Send {
-                    contract: "anchor_mint".to_string(),
+                    contract: "anchor_market".to_string(),
                     amount: Uint128::from(1000000u128),
                     msg: to_binary(&AnchorMarketMsg::RedeemStable {}).unwrap(),
                 })
@@ -148,9 +144,8 @@ fn test_withdraw_addr_recipient() {
 fn test_withdraw_recipient() {
     let mut deps = mock_dependencies_custom(&[]);
     let msg = InstantiateMsg {
-        anchor_token: "aust_token".to_string(),
-        anchor_mint: "anchor_mint".to_string(),
-        stable_denom: "uusd".to_string(),
+        aust_token: "aust_token".to_string(),
+        anchor_market: "anchor_market".to_string(),
     };
     let recipient = String::from("recipient");
     let info = mock_info("addr0000", &[]);
@@ -185,7 +180,7 @@ fn test_withdraw_recipient() {
             CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: "aust_token".to_string(),
                 msg: to_binary(&Cw20ExecuteMsg::Send {
-                    contract: "anchor_mint".to_string(),
+                    contract: "anchor_market".to_string(),
                     amount: Uint128::from(1000000u128),
                     msg: to_binary(&AnchorMarketMsg::RedeemStable {}).unwrap(),
                 })
@@ -211,9 +206,8 @@ fn test_withdraw_recipient() {
 fn test_andr_receive() {
     let mut deps = mock_dependencies_custom(&[]);
     let msg = InstantiateMsg {
-        anchor_token: "aust_token".to_string(),
-        anchor_mint: "anchor_mint".to_string(),
-        stable_denom: "uusd".to_string(),
+        aust_token: "aust_token".to_string(),
+        anchor_market: "anchor_market".to_string(),
     };
     let info = mock_info("addr0000", &[]);
     let _res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -236,7 +230,7 @@ fn test_andr_receive() {
     let expected_res = Response::new()
         .add_submessage(SubMsg::reply_on_success(
             CosmosMsg::Wasm(WasmMsg::Execute {
-                contract_addr: "anchor_mint".to_string(),
+                contract_addr: "anchor_market".to_string(),
                 msg: to_binary(&AnchorMarketMsg::DepositStable {}).unwrap(),
                 funds: vec![coin(1000000u128, "uusd")],
             }),
@@ -270,7 +264,7 @@ fn test_andr_receive() {
             CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: "aust_token".to_string(),
                 msg: to_binary(&Cw20ExecuteMsg::Send {
-                    contract: "anchor_mint".to_string(),
+                    contract: "anchor_market".to_string(),
                     amount: Uint128::from(1000000u128),
                     msg: to_binary(&AnchorMarketMsg::RedeemStable {}).unwrap(),
                 })

--- a/packages/andromeda_protocol/src/anchor.rs
+++ b/packages/andromeda_protocol/src/anchor.rs
@@ -12,9 +12,8 @@ pub enum AnchorMarketMsg {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
-    pub anchor_token: String,
-    pub anchor_mint: String,
-    pub stable_denom: String,
+    pub aust_token: String,
+    pub anchor_market: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -42,7 +41,6 @@ pub enum QueryMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct ConfigResponse {
-    pub anchor_mint: String,
-    pub anchor_token: String,
-    pub stable_denom: String,
+    pub anchor_market: String,
+    pub aust_token: String,
 }

--- a/packages/andromeda_protocol/src/anchor.rs
+++ b/packages/andromeda_protocol/src/anchor.rs
@@ -20,15 +20,13 @@ pub struct InstantiateMsg {
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
     AndrReceive(AndromedaMsg),
-    Deposit { recipient: Option<Recipient> },
-    Withdraw { position_idx: Uint128 },
-    Yourself { yourself_msg: YourselfMsg },
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub enum YourselfMsg {
-    TransferUst { receiver: Recipient },
+    Deposit {
+        recipient: Option<Recipient>,
+    },
+    Withdraw {
+        percent: Option<Uint128>,
+        recipient_addr: String,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/andromeda_protocol/src/anchor.rs
+++ b/packages/andromeda_protocol/src/anchor.rs
@@ -37,8 +37,13 @@ pub enum QueryMsg {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
 pub struct ConfigResponse {
     pub anchor_market: String,
     pub aust_token: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct PositionResponse {
+    pub recipient: Recipient,
+    pub aust_amount: Uint128,
 }

--- a/packages/andromeda_protocol/src/anchor.rs
+++ b/packages/andromeda_protocol/src/anchor.rs
@@ -25,7 +25,7 @@ pub enum ExecuteMsg {
     },
     Withdraw {
         percent: Option<Uint128>,
-        recipient_addr: String,
+        recipient_addr: Option<String>,
     },
 }
 

--- a/packages/andromeda_protocol/src/anchor.rs
+++ b/packages/andromeda_protocol/src/anchor.rs
@@ -5,6 +5,13 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+pub enum WithdrawalType {
+    Amount(Uint128),
+    Percentage(Uint128),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum AnchorMarketMsg {
     DepositStable {},
     RedeemStable {},
@@ -24,7 +31,7 @@ pub enum ExecuteMsg {
         recipient: Option<Recipient>,
     },
     Withdraw {
-        percent: Option<Uint128>,
+        withdrawal_type: Option<WithdrawalType>,
         recipient_addr: Option<String>,
     },
 }


### PR DESCRIPTION
# Motivation
The current implementation used position indices which would generate a new position for each deposit. This is unnecessary in our case so I simplified to group positions by the recipient instead. I also did an overall code cleanup of the contract for easier maintenance in the future.

# Implementation
- I changed the grouping of positions to be under the recipient 
   - Because of this I made it so you could deposit multiple times to the same position
- Removed the `YourselfMsg` for withdrawing ust with a submsg-reply pattern which seems more idiomatic
   - To facilitate this I added new state `RECIPIENT_ADDR` which stores the current recipient address for both withdraws and deposits. This is necessary to have access to that state in the reply.
- Renamed previously unclear variable names
- Allow withdrawing a percentage of the deposited UST in a position as that seems like a very likely usecase



# Testing

## Unit/Integration tests
I wrote one large integration test for depositing and then withdrawing. I also included a few unit tests for more specific cases.

## On-chain tests
I conducted multiple on-chain tests consisting of depositing to the same position multiple times, specifying a custom recipient, and then withdrawing. 

# Future work
We need to also allow withdrawing of aUST instead of just UST for use in other ADOs (like using as collateral in mirror).