### PR TITLE
CU-1xjt52x | Add immutable modules

### DIFF
--- a/contracts/andromeda_cw20/src/testing/tests.rs
+++ b/contracts/andromeda_cw20/src/testing/tests.rs
@@ -23,14 +23,17 @@ fn test_transfer() {
         Module {
             module_type: ModuleType::Receipt,
             instantiate: InstantiateType::Address(MOCK_RECEIPT_CONTRACT.into()),
+            is_mutable: false,
         },
         Module {
             module_type: ModuleType::Rates,
             instantiate: InstantiateType::Address(MOCK_RATES_CONTRACT.into()),
+            is_mutable: false,
         },
         Module {
             module_type: ModuleType::AddressList,
             instantiate: InstantiateType::Address(MOCK_ADDRESSLIST_CONTRACT.into()),
+            is_mutable: false,
         },
     ];
 
@@ -129,14 +132,17 @@ fn test_send() {
         Module {
             module_type: ModuleType::Receipt,
             instantiate: InstantiateType::Address(MOCK_RECEIPT_CONTRACT.into()),
+            is_mutable: false,
         },
         Module {
             module_type: ModuleType::Rates,
             instantiate: InstantiateType::Address(MOCK_RATES_CONTRACT.into()),
+            is_mutable: false,
         },
         Module {
             module_type: ModuleType::AddressList,
             instantiate: InstantiateType::Address(MOCK_ADDRESSLIST_CONTRACT.into()),
+            is_mutable: false,
         },
     ];
 

--- a/contracts/andromeda_cw721/src/testing/mod.rs
+++ b/contracts/andromeda_cw721/src/testing/mod.rs
@@ -392,14 +392,17 @@ fn test_modules() {
         Module {
             module_type: ModuleType::Receipt,
             instantiate: InstantiateType::Address(MOCK_RECEIPT_CONTRACT.into()),
+            is_mutable: false,
         },
         Module {
             module_type: ModuleType::Rates,
             instantiate: InstantiateType::Address(MOCK_RATES_CONTRACT.into()),
+            is_mutable: false,
         },
         Module {
             module_type: ModuleType::AddressList,
             instantiate: InstantiateType::Address(MOCK_ADDRESSLIST_CONTRACT.into()),
+            is_mutable: false,
         },
     ];
 

--- a/packages/andromeda_protocol/src/communication/modules.rs
+++ b/packages/andromeda_protocol/src/communication/modules.rs
@@ -66,6 +66,7 @@ pub enum InstantiateType {
 pub struct Module {
     pub module_type: ModuleType,
     pub instantiate: InstantiateType,
+    pub is_mutable: bool,
 }
 
 /// Struct used to represent a module and its currently recorded address
@@ -153,7 +154,7 @@ impl Module {
     fn is_unique(&self, all_modules: &[Module]) -> bool {
         let mut total = 0;
         all_modules.iter().for_each(|m| {
-            if self == m {
+            if self.module_type == m.module_type {
                 total += 1;
             }
         });
@@ -193,9 +194,7 @@ fn register_module(
 /// Deregisters a module.
 fn deregister_module(storage: &mut dyn Storage, idx: Uint64) -> Result<(), ContractError> {
     let idx_str = idx.to_string();
-    if !MODULE_INFO.has(storage, &idx_str) {
-        return Err(ContractError::ModuleDoesNotExist {});
-    }
+    check_module_mutability(storage, &idx_str)?;
     MODULE_INFO.remove(storage, &idx_str);
     MODULE_ADDR.remove(storage, &idx_str);
 
@@ -213,9 +212,7 @@ fn alter_module(
     module: &Module,
 ) -> Result<(), ContractError> {
     let idx_str = idx.to_string();
-    if !MODULE_INFO.has(storage, &idx_str) {
-        return Err(ContractError::ModuleDoesNotExist {});
-    }
+    check_module_mutability(storage, &idx_str)?;
     MODULE_INFO.save(storage, &idx_str, module)?;
     if let InstantiateType::Address(addr) = &module.instantiate {
         MODULE_ADDR.save(storage, &idx_str, &api.addr_validate(addr)?)?;
@@ -288,6 +285,19 @@ pub fn execute_deregister_module(
     Ok(Response::default()
         .add_attribute("action", "deregister_module")
         .add_attribute("module_idx", module_idx))
+}
+
+fn check_module_mutability(storage: &dyn Storage, idx_str: &str) -> Result<(), ContractError> {
+    let existing_module = MODULE_INFO.may_load(storage, idx_str)?;
+    match existing_module {
+        None => return Err(ContractError::ModuleDoesNotExist {}),
+        Some(m) => {
+            if !m.is_mutable {
+                return Err(ContractError::ModuleImmutable {});
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Loads all registered modules in Vector form
@@ -486,6 +496,7 @@ mod tests {
         let addresslist_module = Module {
             module_type: ModuleType::AddressList,
             instantiate: InstantiateType::Address("".to_string()),
+            is_mutable: false,
         };
 
         let res = addresslist_module.validate(
@@ -497,6 +508,7 @@ mod tests {
         let auction_module = Module {
             module_type: ModuleType::Auction,
             instantiate: InstantiateType::Address("".into()),
+            is_mutable: false,
         };
         addresslist_module
             .validate(
@@ -511,6 +523,7 @@ mod tests {
         let module = Module {
             module_type: ModuleType::Auction,
             instantiate: InstantiateType::Address("".to_string()),
+            is_mutable: false,
         };
 
         let res = module.validate(&[module.clone(), module.clone()], &ADOType::CW721);
@@ -527,6 +540,7 @@ mod tests {
         let other_module = Module {
             module_type: ModuleType::Rates,
             instantiate: InstantiateType::Address("".to_string()),
+            is_mutable: false,
         };
         module
             .validate(&[module.clone(), other_module], &ADOType::CW721)
@@ -538,6 +552,7 @@ mod tests {
         let module = Module {
             module_type: ModuleType::Rates,
             instantiate: InstantiateType::Address("".to_string()),
+            is_mutable: false,
         };
 
         let res = module.validate(&[module.clone(), module.clone()], &ADOType::CW721);
@@ -546,6 +561,7 @@ mod tests {
         let other_module = Module {
             module_type: ModuleType::AddressList,
             instantiate: InstantiateType::Address("".to_string()),
+            is_mutable: false,
         };
         module
             .validate(&[module.clone(), other_module], &ADOType::CW721)
@@ -557,6 +573,7 @@ mod tests {
         let module = Module {
             module_type: ModuleType::Receipt,
             instantiate: InstantiateType::Address("".to_string()),
+            is_mutable: false,
         };
 
         let res = module.validate(&[module.clone(), module.clone()], &ADOType::CW721);
@@ -565,10 +582,29 @@ mod tests {
         let other_module = Module {
             module_type: ModuleType::AddressList,
             instantiate: InstantiateType::Address("".to_string()),
+            is_mutable: false,
         };
         module
             .validate(&[module.clone(), other_module], &ADOType::CW721)
             .unwrap();
+    }
+
+    #[test]
+    fn test_validate_uniqueness() {
+        let module1 = Module {
+            module_type: ModuleType::Receipt,
+            instantiate: InstantiateType::Address("addr1".to_string()),
+            is_mutable: false,
+        };
+
+        let module2 = Module {
+            module_type: ModuleType::Receipt,
+            instantiate: InstantiateType::Address("addr2".to_string()),
+            is_mutable: false,
+        };
+
+        let res = module1.validate(&[module1.clone(), module2], &ADOType::CW721);
+        assert_eq!(ContractError::ModuleNotUnique {}, res.unwrap_err());
     }
 
     #[test]
@@ -578,6 +614,7 @@ mod tests {
         let module = Module {
             module_type: ModuleType::AddressList,
             instantiate: InstantiateType::Address("address".to_string()),
+            is_mutable: false,
         };
         let deps_mut = deps.as_mut();
         CONTRACT_OWNER
@@ -604,6 +641,7 @@ mod tests {
         let module = Module {
             module_type: ModuleType::AddressList,
             instantiate: InstantiateType::Address("address".to_string()),
+            is_mutable: false,
         };
         let deps_mut = deps.as_mut();
         CONTRACT_OWNER
@@ -644,6 +682,7 @@ mod tests {
         let module = Module {
             module_type: ModuleType::Auction,
             instantiate: InstantiateType::Address("address".to_string()),
+            is_mutable: false,
         };
         let deps_mut = deps.as_mut();
         CONTRACT_OWNER
@@ -691,6 +730,7 @@ mod tests {
         let module = Module {
             module_type: ModuleType::AddressList,
             instantiate: InstantiateType::Address("address".to_string()),
+            is_mutable: true,
         };
         CONTRACT_OWNER
             .save(deps.as_mut().storage, &Addr::unchecked("owner"))
@@ -708,6 +748,7 @@ mod tests {
         let module = Module {
             module_type: ModuleType::AddressList,
             instantiate: InstantiateType::Address("address".to_string()),
+            is_mutable: true,
         };
 
         CONTRACT_OWNER
@@ -724,6 +765,7 @@ mod tests {
         let module = Module {
             module_type: ModuleType::Receipt,
             instantiate: InstantiateType::Address("other_address".to_string()),
+            is_mutable: true,
         };
 
         let res =
@@ -748,12 +790,45 @@ mod tests {
     }
 
     #[test]
+    fn test_execute_alter_module_immutable() {
+        let mut deps = mock_dependencies(&[]);
+        let info = mock_info("owner", &[]);
+        let module = Module {
+            module_type: ModuleType::AddressList,
+            instantiate: InstantiateType::Address("address".to_string()),
+            is_mutable: false,
+        };
+
+        CONTRACT_OWNER
+            .save(deps.as_mut().storage, &Addr::unchecked("owner"))
+            .unwrap();
+
+        MODULE_INFO
+            .save(deps.as_mut().storage, "1", &module)
+            .unwrap();
+        MODULE_ADDR
+            .save(deps.as_mut().storage, "1", &Addr::unchecked("address"))
+            .unwrap();
+
+        let module = Module {
+            module_type: ModuleType::Receipt,
+            instantiate: InstantiateType::Address("other_address".to_string()),
+            is_mutable: true,
+        };
+
+        let res = execute_alter_module(deps.as_mut(), info, 1u64.into(), &module, ADOType::CW20);
+
+        assert_eq!(ContractError::ModuleImmutable {}, res.unwrap_err());
+    }
+
+    #[test]
     fn test_execute_alter_module_nonexisting_module() {
         let mut deps = mock_dependencies(&[]);
         let info = mock_info("owner", &[]);
         let module = Module {
             module_type: ModuleType::Auction,
             instantiate: InstantiateType::Address("address".to_string()),
+            is_mutable: true,
         };
 
         CONTRACT_OWNER
@@ -772,6 +847,7 @@ mod tests {
         let module = Module {
             module_type: ModuleType::Auction,
             instantiate: InstantiateType::Address("address".to_string()),
+            is_mutable: true,
         };
 
         CONTRACT_OWNER
@@ -819,6 +895,7 @@ mod tests {
         let module = Module {
             module_type: ModuleType::AddressList,
             instantiate: InstantiateType::Address("address".to_string()),
+            is_mutable: true,
         };
 
         MODULE_INFO
@@ -840,6 +917,32 @@ mod tests {
 
         assert!(!MODULE_ADDR.has(deps.as_mut().storage, "1"));
         assert!(!MODULE_INFO.has(deps.as_mut().storage, "1"));
+    }
+
+    #[test]
+    fn test_execute_deregister_module_immutable() {
+        let mut deps = mock_dependencies(&[]);
+        let info = mock_info("owner", &[]);
+        CONTRACT_OWNER
+            .save(deps.as_mut().storage, &Addr::unchecked("owner"))
+            .unwrap();
+
+        let module = Module {
+            module_type: ModuleType::AddressList,
+            instantiate: InstantiateType::Address("address".to_string()),
+            is_mutable: false,
+        };
+
+        MODULE_INFO
+            .save(deps.as_mut().storage, "1", &module)
+            .unwrap();
+
+        MODULE_ADDR
+            .save(deps.as_mut().storage, "1", &Addr::unchecked("address"))
+            .unwrap();
+
+        let res = execute_deregister_module(deps.as_mut(), info, 1u64.into());
+        assert_eq!(ContractError::ModuleImmutable {}, res.unwrap_err());
     }
 
     #[test]

--- a/packages/andromeda_protocol/src/error.rs
+++ b/packages/andromeda_protocol/src/error.rs
@@ -220,6 +220,9 @@ pub enum ContractError {
 
     #[error("InvalidTokensToWithdraw")]
     InvalidTokensToWithdraw { msg: String },
+
+    #[error("ModuleImmutable")]
+    ModuleImmutable {},
 }
 
 impl From<Cw20ContractError> for ContractError {


### PR DESCRIPTION
# Motivation
Being able to specify a modules mutability is useful both for trust reasons (users will know that rates will not change for instance) and for others I'm sure. 

# Implementation
I just added an `is_mutable` boolean flag to the `Module` struct which disallows altering and de-registering modules that have `is_mutable: false`. 

I also fixed a bug where uniqueness of modules was not working entirely correct. 

# Testing

## Unit/Integration tests
I added unit tests for this.

## On-chain tests
No as it is very simple. 

# Future work
We may want to have immutability at the contract level in the future. 
