### PR TITLE
Wormhole

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "andromeda-wrapped-nft"
+version = "0.1.0"
+dependencies = [
+ "andromeda-protocol",
+ "cosmwasm-std",
+ "cw-storage-plus 0.9.1",
+ "cw2 0.9.1",
+ "cw721",
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contracts/andromeda_wrapped_nft/.cargo/config
+++ b/contracts/andromeda_wrapped_nft/.cargo/config
@@ -1,0 +1,2 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"

--- a/contracts/andromeda_wrapped_nft/.gitignore
+++ b/contracts/andromeda_wrapped_nft/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/contracts/andromeda_wrapped_nft/Cargo.toml
+++ b/contracts/andromeda_wrapped_nft/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "andromeda-wrapped-nft"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+panic = 'abort'
+incremental = false
+overflow-checks = true
+
+[dependencies]
+cosmwasm-std = "0.16.0"
+serde = { version = "1.0.127", default-features = false, features = ["derive"] }
+schemars = "0.8.3"
+cw-storage-plus = "0.9.1"
+cw2 = "0.9.1"
+cw721 = "0.9.2"
+andromeda-protocol = { version = "0.1.0", path = "../../packages/andromeda_protocol" }

--- a/contracts/andromeda_wrapped_nft/src/contract.rs
+++ b/contracts/andromeda_wrapped_nft/src/contract.rs
@@ -1,0 +1,229 @@
+use crate::state::{Config, CONFIG, CUR_TOKEN_ID, TOKENIDS};
+use andromeda_protocol::error::ContractError;
+use andromeda_protocol::wrapped_nft::{MigrateMsg, TokenInfoResponse};
+use andromeda_protocol::{
+    factory::{AddressResponse, ExecuteMsg as FactoryExecuteMsg, QueryMsg as FactoryQueryMsg},
+    token::{ExecuteMsg as TokenExecuteMsg, MintMsg as TokenMintMsg},
+    wrapped_nft::{ConfigResponse, Cw721HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg},
+};
+use cosmwasm_std::{
+    attr, entry_point, from_binary, to_binary, Binary, CanonicalAddr, CosmosMsg, Deps, DepsMut,
+    Env, MessageInfo, QueryRequest, Reply, ReplyOn, Response, StdError, StdResult, SubMsg, WasmMsg,
+    WasmQuery,
+};
+use cw2::{get_contract_version, set_contract_version};
+use cw721::Cw721ReceiveMsg;
+
+pub const REPLY_CREATE_TOKEN: u64 = 1;
+
+// version info for migration info
+const CONTRACT_NAME: &str = "crates.io:andromeda-wrapped-nft";
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[entry_point]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    msg: InstantiateMsg,
+) -> StdResult<Response> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    let config = Config {
+        name: msg.name.clone(),
+        symbol: msg.symbol.clone(),
+        factory_addr: deps
+            .api
+            .addr_canonicalize(msg.andromeda_factory_addr.as_str())?,
+        token_addr: CanonicalAddr::from(vec![]),
+    };
+
+    CONFIG.save(deps.storage, &config)?;
+    CUR_TOKEN_ID.save(deps.storage, &0u64)?;
+
+    let create_token_msg = FactoryExecuteMsg::Create {
+        name: msg.name,
+        symbol: msg.symbol,
+        modules: msg.modules,
+    };
+
+    let create_msg = WasmMsg::Execute {
+        contract_addr: msg.andromeda_factory_addr.to_string(),
+        msg: to_binary(&create_token_msg)?,
+        funds: vec![],
+    };
+
+    let msg = SubMsg {
+        msg: create_msg.into(),
+        gas_limit: None,
+        id: REPLY_CREATE_TOKEN,
+        reply_on: ReplyOn::Always,
+    };
+
+    Ok(Response::new()
+        .add_submessage(msg)
+        .add_attributes(vec![attr("action", "instantiate")]))
+}
+#[entry_point]
+pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> StdResult<Response> {
+    if msg.result.is_err() {
+        return Err(StdError::generic_err(msg.result.unwrap_err()));
+    }
+
+    match msg.id {
+        REPLY_CREATE_TOKEN => on_token_creation_reply(deps, msg),
+        _ => Err(StdError::generic_err("reply id is invalid")),
+    }
+}
+
+fn on_token_creation_reply(deps: DepsMut, _msg: Reply) -> StdResult<Response> {
+    let mut config = CONFIG.load(deps.storage)?;
+
+    let res: AddressResponse = deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
+        contract_addr: deps.api.addr_humanize(&config.factory_addr)?.to_string(),
+        msg: to_binary(&FactoryQueryMsg::GetAddress {
+            symbol: config.symbol.clone(),
+        })?,
+    }))?;
+    config.token_addr = deps.api.addr_canonicalize(&res.address)?;
+    CONFIG.save(deps.storage, &config)?;
+    Ok(Response::new().add_attributes(vec![attr("action", "reply")]))
+}
+
+#[entry_point]
+pub fn execute(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> StdResult<Response> {
+    match msg {
+        ExecuteMsg::ReceiveNft(cw721_msg) => receive_cw721(deps, info, cw721_msg),
+    }
+}
+
+fn receive_cw721(
+    deps: DepsMut,
+    info: MessageInfo,
+    cw721_msg: Cw721ReceiveMsg,
+) -> StdResult<Response> {
+    let nft_addr = info.sender.to_string();
+    match from_binary(&cw721_msg.msg)? {
+        Cw721HookMsg::Wrap {} => {
+            execute_wrap_nft(deps, cw721_msg.sender, nft_addr, cw721_msg.token_id)
+        }
+        Cw721HookMsg::Unwrap {} => {
+            execute_unwrap_nft(deps, cw721_msg.sender, nft_addr, cw721_msg.token_id)
+        }
+    }
+}
+pub fn execute_wrap_nft(
+    deps: DepsMut,
+    sender: String,
+    nft_addr: String,
+    token_id: String,
+) -> StdResult<Response> {
+    let config = CONFIG.load(deps.storage)?;
+    let cur_token_id = CUR_TOKEN_ID.load(deps.storage)?;
+    let create_mint_msg = TokenExecuteMsg::Mint(TokenMintMsg {
+        token_id: cur_token_id.to_string(),
+        owner: sender,
+        name: config.name,
+        token_uri: None,
+        description: None,
+        metadata: None,
+        pricing: None,
+    });
+
+    TOKENIDS.save(
+        deps.storage,
+        cur_token_id.to_string(),
+        &(token_id, nft_addr),
+    )?;
+    CUR_TOKEN_ID.save(deps.storage, &(cur_token_id + 1))?;
+
+    Ok(Response::new()
+        .add_message(CosmosMsg::Wasm(WasmMsg::Execute {
+            contract_addr: deps.api.addr_humanize(&config.token_addr)?.to_string(),
+            msg: to_binary(&create_mint_msg)?,
+            funds: vec![],
+        }))
+        .add_attributes(vec![
+            attr("action", "mint_wrap_nft"),
+            attr("new_token_id", cur_token_id.to_string()),
+        ]))
+}
+pub fn execute_unwrap_nft(
+    deps: DepsMut,
+    sender: String,
+    nft_addr: String,
+    token_id: String,
+) -> StdResult<Response> {
+    let config = CONFIG.load(deps.storage)?;
+    if config.token_addr != deps.api.addr_canonicalize(&nft_addr)? {
+        return Err(StdError::generic_err("nft contract is not this contract"));
+    }
+    let (original_token_id, nft_addr) = TOKENIDS.load(deps.storage, token_id.clone())?;
+    TOKENIDS.remove(deps.storage, token_id.clone());
+
+    Ok(Response::new()
+        .add_messages(vec![
+            CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: deps.api.addr_humanize(&config.token_addr)?.to_string(),
+                msg: to_binary(&TokenExecuteMsg::Burn {
+                    token_id: token_id.clone(),
+                })?,
+                funds: vec![],
+            }),
+            CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: nft_addr,
+                msg: to_binary(&TokenExecuteMsg::TransferNft {
+                    recipient: sender.clone(),
+                    token_id: original_token_id.clone(),
+                })?,
+                funds: vec![],
+            }),
+        ])
+        .add_attributes(vec![
+            attr("action", "unwrap_nft"),
+            attr("burn_token_id", token_id),
+            attr("receiver", sender.clone()),
+            attr("token_id", original_token_id.clone()),
+        ]))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    let version = get_contract_version(deps.storage)?;
+    if version.contract != CONTRACT_NAME {
+        return Err(ContractError::CannotMigrate {
+            previous_contract: version.contract,
+        });
+    }
+    Ok(Response::default())
+}
+
+#[entry_point]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Config {} => to_binary(&query_config(deps)?),
+        QueryMsg::TokenInfo { token_id } => to_binary(&query_token_info(deps, token_id)?),
+    }
+}
+
+fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
+    let config = CONFIG.load(deps.storage)?;
+    Ok(ConfigResponse {
+        name: config.name,
+        symbol: config.symbol,
+        factory_addr: deps.api.addr_humanize(&config.factory_addr)?.to_string(),
+        token_addr: deps.api.addr_humanize(&config.factory_addr)?.to_string(),
+    })
+}
+
+fn query_token_info(deps: Deps, token_id: String) -> StdResult<TokenInfoResponse> {
+    let token_info = TOKENIDS.load(deps.storage, token_id)?;
+    Ok(TokenInfoResponse {
+        original_token_id: token_info.0,
+        original_token_addr: token_info.1,
+    })
+}

--- a/contracts/andromeda_wrapped_nft/src/contract.rs
+++ b/contracts/andromeda_wrapped_nft/src/contract.rs
@@ -186,8 +186,8 @@ pub fn execute_unwrap_nft(
         .add_attributes(vec![
             attr("action", "unwrap_nft"),
             attr("burn_token_id", token_id),
-            attr("receiver", sender.clone()),
-            attr("token_id", original_token_id.clone()),
+            attr("receiver", sender),
+            attr("token_id", original_token_id),
         ]))
 }
 

--- a/contracts/andromeda_wrapped_nft/src/lib.rs
+++ b/contracts/andromeda_wrapped_nft/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod contract;
+pub mod state;
+#[cfg(test)]
+mod testing;

--- a/contracts/andromeda_wrapped_nft/src/state.rs
+++ b/contracts/andromeda_wrapped_nft/src/state.rs
@@ -1,0 +1,18 @@
+use cosmwasm_std::CanonicalAddr;
+use cw_storage_plus::{Item, Map};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+pub const CONFIG: Item<Config> = Item::new("config");
+
+// key: new_token_id, value: (original_token_id, original_nft_addr)
+pub const TOKENIDS: Map<String, (String, String)> = Map::new("token_ids");
+pub const CUR_TOKEN_ID: Item<u64> = Item::new("current_token_id");
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct Config {
+    pub name: String,
+    pub symbol: String,
+    pub factory_addr: CanonicalAddr,
+    pub token_addr: CanonicalAddr,
+}

--- a/contracts/andromeda_wrapped_nft/src/testing/mod.rs
+++ b/contracts/andromeda_wrapped_nft/src/testing/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+mod tests;

--- a/contracts/andromeda_wrapped_nft/src/testing/tests.rs
+++ b/contracts/andromeda_wrapped_nft/src/testing/tests.rs
@@ -1,0 +1,159 @@
+use crate::contract::{execute_unwrap_nft, execute_wrap_nft, instantiate, REPLY_CREATE_TOKEN};
+use crate::state::CONFIG;
+use andromeda_protocol::{
+    factory::ExecuteMsg as FactoryExecuteMsg,
+    token::{ExecuteMsg as TokenExecuteMsg, MintMsg as TokenMintMsg},
+    wrapped_nft::InstantiateMsg,
+};
+use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
+use cosmwasm_std::{attr, to_binary, Addr, Api, CosmosMsg, ReplyOn, Response, SubMsg, WasmMsg};
+
+#[test]
+fn test_instantiate() {
+    let owner = "creator";
+    let mut deps = mock_dependencies(&[]);
+    let env = mock_env();
+    let info = mock_info(owner, &[]);
+    let msg = InstantiateMsg {
+        andromeda_factory_addr: Addr::unchecked("FACTORY_ADDR"),
+        name: "WRAPP_NFT".to_string(),
+        symbol: "WNFT".to_string(),
+        modules: vec![],
+    };
+    let res = instantiate(deps.as_mut(), env, info, msg).unwrap();
+    assert_eq!(
+        res,
+        Response::new()
+            .add_submessage(SubMsg {
+                msg: CosmosMsg::Wasm(WasmMsg::Execute {
+                    contract_addr: "FACTORY_ADDR".to_string(),
+                    msg: to_binary(&FactoryExecuteMsg::Create {
+                        name: "WRAPP_NFT".to_string(),
+                        symbol: "WNFT".to_string(),
+                        modules: vec![],
+                    })
+                    .unwrap(),
+                    funds: vec![]
+                }),
+                gas_limit: None,
+                id: REPLY_CREATE_TOKEN,
+                reply_on: ReplyOn::Always
+            })
+            .add_attributes(vec![attr("action", "instantiate")])
+    );
+}
+
+#[test]
+fn test_execute_wrap_nft() {
+    let mut deps = mock_dependencies(&[]);
+    let env = mock_env();
+    let info = mock_info("OWNER", &[]);
+
+    let msg = InstantiateMsg {
+        andromeda_factory_addr: Addr::unchecked("FACTORY_ADDR"),
+        name: "WRAPP_NFT".to_string(),
+        symbol: "WNFT".to_string(),
+        modules: vec![],
+    };
+    let _ = instantiate(deps.as_mut(), env, info, msg).unwrap();
+    let mut config = CONFIG.load(&deps.storage).unwrap();
+    config.token_addr = deps.api.addr_canonicalize("WRAP_TOKEN_ADDR").unwrap();
+
+    CONFIG.save(deps.as_mut().storage, &config).unwrap();
+
+    let sender = "NFT_OWNER1".to_string();
+    let nft_addr = "NFT_ADDR1".to_string();
+    let token_id = "NFT_TOKEN_ID_1".to_string();
+
+    let res = execute_wrap_nft(deps.as_mut(), sender, nft_addr, token_id).unwrap();
+    assert_eq!(
+        res,
+        Response::new()
+            .add_message(CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: "WRAP_TOKEN_ADDR".to_string(),
+                msg: to_binary(&TokenExecuteMsg::Mint(TokenMintMsg {
+                    token_id: "0".to_string(),
+                    owner: "NFT_OWNER1".to_string(),
+                    name: "WRAPP_NFT".to_string(),
+                    token_uri: None,
+                    description: None,
+                    metadata: None,
+                    pricing: None
+                }))
+                .unwrap(),
+                funds: vec![]
+            }))
+            .add_attributes(vec![
+                attr("action", "mint_wrap_nft"),
+                attr("new_token_id", "0".to_string())
+            ])
+    );
+}
+
+#[test]
+fn test_execute_unwrap_nft() {
+    let mut deps = mock_dependencies(&[]);
+    let env = mock_env();
+    let info = mock_info("OWNER", &[]);
+
+    let msg = InstantiateMsg {
+        andromeda_factory_addr: Addr::unchecked("FACTORY_ADDR"),
+        name: "WRAPP_NFT".to_string(),
+        symbol: "WNFT".to_string(),
+        modules: vec![],
+    };
+    let _ = instantiate(deps.as_mut(), env, info, msg).unwrap();
+    let mut config = CONFIG.load(&deps.storage).unwrap();
+    config.token_addr = deps.api.addr_canonicalize("WRAP_TOKEN_ADDR").unwrap();
+
+    CONFIG.save(deps.as_mut().storage, &config).unwrap();
+
+    let sender = "NFT_OWNER1".to_string();
+    let nft_addr = "NFT_ADDR1".to_string();
+    let token_id = "NFT_TOKEN_ID_1".to_string();
+
+    let _res = execute_wrap_nft(
+        deps.as_mut(),
+        sender.clone(),
+        nft_addr.clone(),
+        token_id.clone(),
+    )
+    .unwrap();
+
+    let res = execute_unwrap_nft(
+        deps.as_mut(),
+        sender,
+        "WRAP_TOKEN_ADDR".to_string(),
+        "0".to_string(),
+    )
+    .unwrap();
+    assert_eq!(
+        res,
+        Response::new()
+            .add_messages(vec![
+                CosmosMsg::Wasm(WasmMsg::Execute {
+                    contract_addr: "WRAP_TOKEN_ADDR".to_string(),
+                    msg: to_binary(&TokenExecuteMsg::Burn {
+                        token_id: "0".to_string(),
+                    })
+                    .unwrap(),
+                    funds: vec![],
+                }),
+                CosmosMsg::Wasm(WasmMsg::Execute {
+                    contract_addr: "NFT_ADDR1".to_string(),
+                    msg: to_binary(&TokenExecuteMsg::TransferNft {
+                        recipient: "NFT_OWNER1".to_string(),
+                        token_id: "NFT_TOKEN_ID_1".to_string(),
+                    })
+                    .unwrap(),
+                    funds: vec![],
+                }),
+            ])
+            .add_attributes(vec![
+                attr("action", "unwrap_nft"),
+                attr("burn_token_id", "0"),
+                attr("receiver", "NFT_OWNER1"),
+                attr("token_id", "NFT_TOKEN_ID_1"),
+            ])
+    )
+}

--- a/contracts/andromeda_wrapped_nft/src/testing/tests.rs
+++ b/contracts/andromeda_wrapped_nft/src/testing/tests.rs
@@ -112,13 +112,7 @@ fn test_execute_unwrap_nft() {
     let nft_addr = "NFT_ADDR1".to_string();
     let token_id = "NFT_TOKEN_ID_1".to_string();
 
-    let _res = execute_wrap_nft(
-        deps.as_mut(),
-        sender.clone(),
-        nft_addr.clone(),
-        token_id.clone(),
-    )
-    .unwrap();
+    let _res = execute_wrap_nft(deps.as_mut(), sender.clone(), nft_addr, token_id).unwrap();
 
     let res = execute_unwrap_nft(
         deps.as_mut(),

--- a/packages/andromeda_protocol/src/lib.rs
+++ b/packages/andromeda_protocol/src/lib.rs
@@ -15,6 +15,7 @@ pub mod rates;
 pub mod receipt;
 pub mod response;
 pub mod splitter;
+pub mod wrapped_nft;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod testing;

--- a/packages/andromeda_protocol/src/wrapped_nft.rs
+++ b/packages/andromeda_protocol/src/wrapped_nft.rs
@@ -1,0 +1,48 @@
+use crate::modules::ModuleDefinition;
+use cosmwasm_std::Addr;
+use cw721::Cw721ReceiveMsg;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct InstantiateMsg {
+    pub andromeda_factory_addr: Addr,
+    pub name: String,
+    pub symbol: String,
+    pub modules: Vec<ModuleDefinition>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+    ReceiveNft(Cw721ReceiveMsg),
+}
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+pub struct MigrateMsg {}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    Config {},
+    TokenInfo { token_id: String },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum Cw721HookMsg {
+    Wrap {},
+    Unwrap {},
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+pub struct ConfigResponse {
+    pub name: String,
+    pub symbol: String,
+    pub factory_addr: String,
+    pub token_addr: String,
+}
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+pub struct TokenInfoResponse {
+    pub original_token_id: String,
+    pub original_token_addr: String,
+}


### PR DESCRIPTION
# Motivation
Wormhole WCDP

# Implementation
Implement new functionality of Wormhole WCDP

# Testing

## Unit/Integration tests

## On-chain tests
- andromeda_wrapped_nft for wormhole

* instantiate
  execute the "create" of andromeda_factory contract to create andromeda-token contract,
  and store the address of new created token contract.

* wrap
  user sends andromeda-token(NFT) to andromeda_wrapped_nft contract with "wrap" message.
  in this case, andromeda_wrapped_nft contract will mint token using token contract address stored in instantiate,
  at that time, the owner of new minted token will set andromeda-token's sender.
* unwrap
  user sends andromeda-wrapped-nft token(NFT) to andromeda_wrapped_nft contract with "unwrap" message.
  in this case, andromeda_wrapped_nft contract will burn this token and transfer stored andromeda-token to sender.

# Future work
Need to be checked
