### PR TITLE
Split off module functionality into its own feature in ado_base

### DIFF
--- a/contracts/andromeda_addresslist/Cargo.toml
+++ b/contracts/andromeda_addresslist/Cargo.toml
@@ -33,7 +33,7 @@ cw-storage-plus = "0.9.1"
 cw2 = "0.9.1"
 andromeda-protocol = { version = "0.1.0", path = "../../packages/andromeda_protocol" }
 common = { version = "0.1.0", path = "../../packages/common" }
-ado-base = { path = "../../packages/ado_base", version = "0.1.0", default-features= false, features = ["library"]}
+ado-base = { path = "../../packages/ado_base", version = "0.1.0"}
 
 [dev-dependencies]
 cosmwasm-schema = { version = "0.16.0" }

--- a/contracts/andromeda_anchor/Cargo.toml
+++ b/contracts/andromeda_anchor/Cargo.toml
@@ -29,7 +29,7 @@ cw2 = "0.9.1"
 terraswap = "2.4.0"
 andromeda-protocol = { version = "0.1.0", path = "../../packages/andromeda_protocol" }
 common = { version = "0.1.0", path = "../../packages/common" }
-ado-base = { path = "../../packages/ado_base", version = "0.1.0", default-features= false, features = ["library"]}
+ado-base = { path = "../../packages/ado_base", version = "0.1.0"}
 
 [dev-dependencies]
 terra-cosmwasm = { version = "2.2.0" }

--- a/contracts/andromeda_astroport/Cargo.toml
+++ b/contracts/andromeda_astroport/Cargo.toml
@@ -30,7 +30,7 @@ terraswap = "2.4.0"
 astroport = "1.0.1"
 andromeda-protocol = { version = "0.1.0", path = "../../packages/andromeda_protocol" }
 common = { version = "0.1.0", path = "../../packages/common" }
-ado-base = { path = "../../packages/ado_base", version = "0.1.0", default-features= false, features = ["library"]}
+ado-base = { path = "../../packages/ado_base", version = "0.1.0"}
 
 [dev-dependencies]
 terra-cosmwasm = { version = "2.2.0" }

--- a/contracts/andromeda_auction/Cargo.toml
+++ b/contracts/andromeda_auction/Cargo.toml
@@ -27,7 +27,7 @@ cw-storage-plus = "0.9.1"
 cw721 = "0.9.1"
 andromeda-protocol = { version = "0.1.0", path = "../../packages/andromeda_protocol" }
 common = { version = "0.1.0", path = "../../packages/common" }
-ado-base = { path = "../../packages/ado_base", version = "0.1.0", default-features= false, features = ["library"]}
+ado-base = { path = "../../packages/ado_base", version = "0.1.0"}
 
 [dev-dependencies]
 terra-cosmwasm = { version = "2.2.0" }

--- a/contracts/andromeda_cw20/Cargo.toml
+++ b/contracts/andromeda_cw20/Cargo.toml
@@ -46,7 +46,7 @@ schemars = "0.8.3"
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 andromeda-protocol = { version = "0.1.0", path = "../../packages/andromeda_protocol" }
 common = { version = "0.1.0", path = "../../packages/common" }
-ado-base = { path = "../../packages/ado_base", version = "0.1.0", default-features= false, features = ["library"]}
+ado-base = { path = "../../packages/ado_base", version = "0.1.0", features = ["modules"]}
 cw20 = "0.9.1"
 cw2 = "0.9.1"
 cw20-base = { version = "0.9.1", features = ["library"] }

--- a/contracts/andromeda_cw20/src/contract.rs
+++ b/contracts/andromeda_cw20/src/contract.rs
@@ -11,10 +11,8 @@ use andromeda_protocol::{
     response::get_reply_address,
 };
 use common::{
-    ado_base::{hooks::AndromedaHook},
-    error::ContractError,
-    primitive::PRIMITVE_CONTRACT,
-    require, Funds,
+    ado_base::hooks::AndromedaHook, error::ContractError, primitive::PRIMITVE_CONTRACT, require,
+    Funds,
 };
 use cw2::{get_contract_version, set_contract_version};
 use cw20::{Cw20Coin, Cw20ExecuteMsg};

--- a/contracts/andromeda_cw20/src/testing/tests.rs
+++ b/contracts/andromeda_cw20/src/testing/tests.rs
@@ -1,4 +1,5 @@
 use crate::contract::{execute, instantiate};
+use ado_base::ADOContract;
 use andromeda_protocol::{
     address_list::InstantiateMsg as AddressListInstantiateMsg,
     cw20::{ExecuteMsg, InstantiateMsg},
@@ -68,6 +69,20 @@ fn test_instantiate_modules() {
     };
 
     let res = instantiate(deps.as_mut(), mock_env(), info, instantiate_msg).unwrap();
+    assert_eq!(
+        "sender",
+        ADOContract::default()
+            .owner
+            .load(deps.as_mut().storage)
+            .unwrap()
+    );
+    assert_eq!(
+        "cw20",
+        ADOContract::default()
+            .ado_type
+            .load(deps.as_mut().storage)
+            .unwrap()
+    );
 
     let msgs: Vec<SubMsg> = vec![
         SubMsg {

--- a/contracts/andromeda_cw721/Cargo.toml
+++ b/contracts/andromeda_cw721/Cargo.toml
@@ -45,7 +45,7 @@ schemars = "0.8.3"
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 andromeda-protocol = { version = "0.1.0", path = "../../packages/andromeda_protocol" }
 common = { version = "0.1.0", path = "../../packages/common" }
-ado-base = { path = "../../packages/ado_base", version = "0.1.0", default-features= false, features = ["library"]}
+ado-base = { path = "../../packages/ado_base", version = "0.1.0", features = ["modules"]}
 cw721-base = { version = "0.9.1", features = ["library"] }
 
 [dev-dependencies]

--- a/contracts/andromeda_cw721/src/testing/mod.rs
+++ b/contracts/andromeda_cw721/src/testing/mod.rs
@@ -5,6 +5,7 @@ use cosmwasm_std::{
     Uint128, WasmMsg,
 };
 
+use ado_base::ADOContract;
 use common::{
     ado_base::{
         hooks::{AndromedaHook, OnFundsTransferResponse},
@@ -99,6 +100,21 @@ fn test_instantiate_modules() {
     };
 
     let res = instantiate(deps.as_mut(), mock_env(), info, instantiate_msg).unwrap();
+
+    assert_eq!(
+        "sender",
+        ADOContract::default()
+            .owner
+            .load(deps.as_mut().storage)
+            .unwrap()
+    );
+    assert_eq!(
+        "cw721",
+        ADOContract::default()
+            .ado_type
+            .load(deps.as_mut().storage)
+            .unwrap()
+    );
 
     let msgs: Vec<SubMsg> = vec![
         SubMsg {

--- a/contracts/andromeda_cw721_offers/Cargo.toml
+++ b/contracts/andromeda_cw721_offers/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.26" }
 andromeda-protocol = { version = "0.1.0", path = "../../packages/andromeda_protocol" }
 common = { version = "0.1.0", path = "../../packages/common" }
-ado-base = { path = "../../packages/ado_base", version = "0.1.0", default-features= false, features = ["library"]}
+ado-base = { path = "../../packages/ado_base", version = "0.1.0"}
 cw721 = "0.9.1"
 cw721-base = { version = "0.9.1", features = ["library"] }
 

--- a/contracts/andromeda_factory/Cargo.toml
+++ b/contracts/andromeda_factory/Cargo.toml
@@ -36,7 +36,7 @@ cw-storage-plus = "0.9.1"
 schemars = "0.8.3"
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 andromeda-protocol = { version = "0.1.0", path = "../../packages/andromeda_protocol" }
-ado-base = { path = "../../packages/ado_base", version = "0.1.0", default-features= false, features = ["library"]}
+ado-base = { path = "../../packages/ado_base", version = "0.1.0" }
 common = { version = "0.1.0", path = "../../packages/common" }
 cw721 = "0.9.1"
 cw2 = "0.9.1"

--- a/contracts/andromeda_mirror_wrapped_cdp/Cargo.toml
+++ b/contracts/andromeda_mirror_wrapped_cdp/Cargo.toml
@@ -27,7 +27,7 @@ schemars = "0.8.3"
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.26" }
 andromeda-protocol = { version = "0.1.0", path = "../../packages/andromeda_protocol" }
-ado-base = { path = "../../packages/ado_base", version = "0.1.0", default-features= false, features = ["library", "withdraw"]}
+ado-base = { path = "../../packages/ado_base", version = "0.1.0", features = ["withdraw"]}
 common = { version = "0.1.0", path = "../../packages/common" }
 mirror-protocol = "2.1.1"
 terraswap = {version = "2.4.0"}

--- a/contracts/andromeda_primitive/Cargo.toml
+++ b/contracts/andromeda_primitive/Cargo.toml
@@ -27,7 +27,7 @@ schemars = "0.8.3"
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.26" }
 andromeda-protocol = { version = "0.1.0", path = "../../packages/andromeda_protocol" }
-ado-base = { path = "../../packages/ado_base", version = "0.1.0", default-features= false, features = ["library"]}
+ado-base = { path = "../../packages/ado_base", version = "0.1.0" }
 common = { version = "0.1.0", path = "../../packages/common" }
 
 [dev-dependencies]

--- a/contracts/andromeda_rates/Cargo.toml
+++ b/contracts/andromeda_rates/Cargo.toml
@@ -27,5 +27,5 @@ cw-storage-plus = "0.9.1"
 cw2 = "0.9.1"
 cw20 = "0.9.1"
 andromeda-protocol = { version = "0.1.0", path = "../../packages/andromeda_protocol" }
-ado-base = { path = "../../packages/ado_base", version = "0.1.0", default-features= false, features = ["library"]}
+ado-base = { path = "../../packages/ado_base", version = "0.1.0" }
 common = { version = "0.1.0", path = "../../packages/common" }

--- a/contracts/andromeda_receipt/Cargo.toml
+++ b/contracts/andromeda_receipt/Cargo.toml
@@ -26,5 +26,5 @@ schemars = "0.8.3"
 cw-storage-plus = "0.9.1"
 cw2 = "0.9.1"
 andromeda-protocol = { version = "0.1.0", path = "../../packages/andromeda_protocol" }
-ado-base = { path = "../../packages/ado_base", version = "0.1.0", default-features= false, features = ["library"]}
+ado-base = { path = "../../packages/ado_base", version = "0.1.0" }
 common = { version = "0.1.0", path = "../../packages/common" }

--- a/contracts/andromeda_splitter/Cargo.toml
+++ b/contracts/andromeda_splitter/Cargo.toml
@@ -24,5 +24,5 @@ schemars = "0.8.3"
 cw-storage-plus = "0.9.1"
 cw2 = "0.9.1"
 andromeda-protocol = { version = "0.1.0", path = "../../packages/andromeda_protocol" }
-ado-base = { path = "../../packages/ado_base", version = "0.1.0", default-features= false, features = ["library"]}
+ado-base = { path = "../../packages/ado_base", version = "0.1.0" }
 common = { version = "0.1.0", path = "../../packages/common" }

--- a/contracts/andromeda_swapper/Cargo.toml
+++ b/contracts/andromeda_swapper/Cargo.toml
@@ -27,7 +27,7 @@ cw-storage-plus = "0.9.1"
 cw20 = { version = "0.9.1" }
 cw2 = "0.9.1"
 andromeda-protocol = { version = "0.1.0", path = "../../packages/andromeda_protocol" }
-ado-base = { path = "../../packages/ado_base", version = "0.1.0", default-features= false, features = ["library"]}
+ado-base = { path = "../../packages/ado_base", version = "0.1.0" }
 common = { version = "0.1.0", path = "../../packages/common" }
 
 [dev-dependencies]

--- a/contracts/andromeda_timelock/Cargo.toml
+++ b/contracts/andromeda_timelock/Cargo.toml
@@ -23,7 +23,7 @@ overflow-checks = true
 cosmwasm-std = "0.16.0"
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 andromeda-protocol = { version = "0.1.0", path = "../../packages/andromeda_protocol" }
-ado-base = { path = "../../packages/ado_base", version = "0.1.0", default-features= false, features = ["library"]}
+ado-base = { path = "../../packages/ado_base", version = "0.1.0" }
 common = { version = "0.1.0", path = "../../packages/common" }
 schemars = "0.8.3"
 cw-storage-plus = "0.9.1"

--- a/contracts/andromeda_wrapped_cw721/Cargo.toml
+++ b/contracts/andromeda_wrapped_cw721/Cargo.toml
@@ -26,7 +26,7 @@ schemars = "0.8.3"
 cw-storage-plus = "0.9.1"
 cw721 = "0.9.1"
 andromeda-protocol = { version = "0.1.0", path = "../../packages/andromeda_protocol" }
-ado-base = { path = "../../packages/ado_base", version = "0.1.0", default-features= false, features = ["library"]}
+ado-base = { path = "../../packages/ado_base", version = "0.1.0" }
 cw721-base = { version = "0.9.1", features = ["library"] }
 common = { version = "0.1.0", path = "../../packages/common" }
 

--- a/packages/ado_base/Cargo.toml
+++ b/packages/ado_base/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-# use library feature to disable all instantiate/execute/query exports
 withdraw = ["terraswap", "cw20"]
 modules = []
 

--- a/packages/ado_base/Cargo.toml
+++ b/packages/ado_base/Cargo.toml
@@ -10,8 +10,8 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 # use library feature to disable all instantiate/execute/query exports
-library = []
 withdraw = ["terraswap", "cw20"]
+modules = []
 
 [profile.release]
 opt-level = 3

--- a/packages/ado_base/src/lib.rs
+++ b/packages/ado_base/src/lib.rs
@@ -1,6 +1,7 @@
 mod execute;
 #[cfg(test)]
 pub mod mock_querier;
+#[cfg(feature = "modules")]
 pub mod modules;
 mod query;
 pub mod state;

--- a/packages/ado_base/src/state.rs
+++ b/packages/ado_base/src/state.rs
@@ -1,8 +1,6 @@
-use common::{
-    ado_base::{modules::Module, QueryMsg},
-    error::ContractError,
-    parse_message,
-};
+#[cfg(feature = "modules")]
+use common::ado_base::modules::Module;
+use common::{ado_base::QueryMsg, error::ContractError, parse_message};
 use cosmwasm_std::{Addr, Binary, Storage};
 use cw_storage_plus::{Item, Map};
 #[cfg(feature = "withdraw")]
@@ -11,8 +9,12 @@ use terraswap::asset::AssetInfo;
 pub struct ADOContract<'a> {
     pub owner: Item<'a, Addr>,
     pub operators: Map<'a, &'a str, bool>,
+    pub ado_type: Item<'a, String>,
+    #[cfg(feature = "modules")]
     pub module_info: Map<'a, &'a str, Module>,
+    #[cfg(feature = "modules")]
     pub module_addr: Map<'a, &'a str, Addr>,
+    #[cfg(feature = "modules")]
     pub module_idx: Item<'a, u64>,
     #[cfg(feature = "withdraw")]
     pub withdrawable_tokens: Map<'a, &'a str, AssetInfo>,
@@ -23,16 +25,18 @@ impl<'a> Default for ADOContract<'a> {
         ADOContract {
             owner: Item::new("owner"),
             operators: Map::new("operators"),
+            ado_type: Item::new("ado_type"),
+            #[cfg(feature = "modules")]
             module_info: Map::new("andr_modules"),
+            #[cfg(feature = "modules")]
             module_addr: Map::new("andr_module_addresses"),
+            #[cfg(feature = "modules")]
             module_idx: Item::new("andr_module_idx"),
             #[cfg(feature = "withdraw")]
             withdrawable_tokens: Map::new("withdrawable_tokens"),
         }
     }
 }
-
-impl<'a> ADOContract<'a> {}
 
 impl<'a> ADOContract<'a> {
     /// Helper function to query if a given address is a operator.

--- a/packages/andromeda_protocol/src/cw20.rs
+++ b/packages/andromeda_protocol/src/cw20.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Binary, Uint128, Uint64};
+use cosmwasm_std::{Binary, Uint128};
 use cw0::Expiration;
 use cw20::{Cw20Coin, Logo, MinterResponse};
 use cw20_base::msg::{
@@ -8,7 +8,7 @@ use cw20_base::msg::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use common::ado_base::modules::Module;
+use common::ado_base::{modules::Module, AndromedaMsg};
 
 #[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]
 pub struct InstantiateMsg {
@@ -109,17 +109,7 @@ pub enum ExecuteMsg {
     },
     /// If set as the "marketing" role on the contract, upload a new URL, SVG, or PNG for the token
     UploadLogo(Logo),
-
-    RegisterModule {
-        module: Module,
-    },
-    DeregisterModule {
-        module_idx: Uint64,
-    },
-    AlterModule {
-        module_idx: Uint64,
-        module: Module,
-    },
+    AndrReceive(AndromedaMsg),
 }
 
 impl From<ExecuteMsg> for Cw20ExecuteMsg {

--- a/packages/andromeda_protocol/src/cw721.rs
+++ b/packages/andromeda_protocol/src/cw721.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{attr, BankMsg, Binary, Coin, Event, Uint64};
+use cosmwasm_std::{attr, BankMsg, Binary, Coin, Event};
 use cw721::Expiration;
 use cw721_base::{
     ExecuteMsg as Cw721ExecuteMsg, InstantiateMsg as Cw721InstantiateMsg, MintMsg,
@@ -192,16 +192,6 @@ pub enum ExecuteMsg {
     TransferAgreement {
         token_id: String,
         agreement: Option<TransferAgreement>,
-    },
-    RegisterModule {
-        module: Module,
-    },
-    DeregisterModule {
-        module_idx: Uint64,
-    },
-    AlterModule {
-        module_idx: Uint64,
-        module: Module,
     },
 }
 

--- a/packages/common/src/ado_base/mod.rs
+++ b/packages/common/src/ado_base/mod.rs
@@ -4,8 +4,12 @@ pub mod operators;
 pub mod ownership;
 pub mod recipient;
 
-use crate::{ado_base::recipient::Recipient, error::ContractError, withdraw::Withdrawal};
-use cosmwasm_std::{to_binary, Binary, QuerierWrapper, QueryRequest, WasmQuery};
+use crate::{
+    ado_base::{modules::Module, recipient::Recipient},
+    error::ContractError,
+    withdraw::Withdrawal,
+};
+use cosmwasm_std::{to_binary, Binary, QuerierWrapper, QueryRequest, Uint64, WasmQuery};
 use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
@@ -29,6 +33,16 @@ pub enum AndromedaMsg {
     Withdraw {
         recipient: Option<Recipient>,
         tokens_to_withdraw: Option<Vec<Withdrawal>>,
+    },
+    RegisterModule {
+        module: Module,
+    },
+    DeregisterModule {
+        module_idx: Uint64,
+    },
+    AlterModule {
+        module_idx: Uint64,
+        module: Module,
     },
 }
 

--- a/packages/common/src/ado_base/modules.rs
+++ b/packages/common/src/ado_base/modules.rs
@@ -43,13 +43,6 @@ pub struct ModuleInfoWithAddress {
     pub address: String,
 }
 
-/// The type of ADO that is using these modules.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub enum ADOType {
-    CW721,
-    CW20,
-}
-
 impl Module {
     /// Queries the code id for a module from the factory contract
     pub fn get_code_id(
@@ -105,10 +98,10 @@ impl Module {
 
     /// Validates `self` by checking that it is unique, does not conflict with any other module,
     /// and does not conflict with the creating ADO.
-    pub fn validate(&self, modules: &[Module], ado_type: &ADOType) -> Result<(), ContractError> {
+    pub fn validate(&self, modules: &[Module], ado_type: &str) -> Result<(), ContractError> {
         require(self.is_unique(modules), ContractError::ModuleNotUnique {})?;
 
-        if ado_type == &ADOType::CW20 && contains_module(modules, AUCTION) {
+        if ado_type == "cw20" && contains_module(modules, AUCTION) {
             return Err(ContractError::IncompatibleModules {
                 msg: "An Auction module cannot be used for a CW20 ADO".to_string(),
             });
@@ -154,7 +147,7 @@ mod tests {
 
         let res = addresslist_module.validate(
             &[addresslist_module.clone(), addresslist_module.clone()],
-            &ADOType::CW721,
+            "cw721",
         );
         assert_eq!(ContractError::ModuleNotUnique {}, res.unwrap_err());
 
@@ -164,10 +157,7 @@ mod tests {
             is_mutable: false,
         };
         addresslist_module
-            .validate(
-                &[addresslist_module.clone(), auction_module],
-                &ADOType::CW721,
-            )
+            .validate(&[addresslist_module.clone(), auction_module], "cw721")
             .unwrap();
     }
 
@@ -179,10 +169,10 @@ mod tests {
             is_mutable: false,
         };
 
-        let res = module.validate(&[module.clone(), module.clone()], &ADOType::CW721);
+        let res = module.validate(&[module.clone(), module.clone()], "cw721");
         assert_eq!(ContractError::ModuleNotUnique {}, res.unwrap_err());
 
-        let res = module.validate(&[module.clone()], &ADOType::CW20);
+        let res = module.validate(&[module.clone()], "cw20");
         assert_eq!(
             ContractError::IncompatibleModules {
                 msg: "An Auction module cannot be used for a CW20 ADO".to_string()
@@ -196,7 +186,7 @@ mod tests {
             is_mutable: false,
         };
         module
-            .validate(&[module.clone(), other_module], &ADOType::CW721)
+            .validate(&[module.clone(), other_module], "cw721")
             .unwrap();
     }
 
@@ -208,7 +198,7 @@ mod tests {
             is_mutable: false,
         };
 
-        let res = module.validate(&[module.clone(), module.clone()], &ADOType::CW721);
+        let res = module.validate(&[module.clone(), module.clone()], "cw721");
         assert_eq!(ContractError::ModuleNotUnique {}, res.unwrap_err());
 
         let other_module = Module {
@@ -217,7 +207,7 @@ mod tests {
             is_mutable: false,
         };
         module
-            .validate(&[module.clone(), other_module], &ADOType::CW721)
+            .validate(&[module.clone(), other_module], "cw721")
             .unwrap();
     }
 
@@ -229,7 +219,7 @@ mod tests {
             is_mutable: false,
         };
 
-        let res = module.validate(&[module.clone(), module.clone()], &ADOType::CW721);
+        let res = module.validate(&[module.clone(), module.clone()], "cw721");
         assert_eq!(ContractError::ModuleNotUnique {}, res.unwrap_err());
 
         let other_module = Module {
@@ -238,7 +228,7 @@ mod tests {
             is_mutable: false,
         };
         module
-            .validate(&[module.clone(), other_module], &ADOType::CW721)
+            .validate(&[module.clone(), other_module], "cw721")
             .unwrap();
     }
 
@@ -256,7 +246,7 @@ mod tests {
             is_mutable: false,
         };
 
-        let res = module1.validate(&[module1.clone(), module2], &ADOType::CW721);
+        let res = module1.validate(&[module1.clone(), module2], "cw721");
         assert_eq!(ContractError::ModuleNotUnique {}, res.unwrap_err());
     }
 }


### PR DESCRIPTION
# Motivation
Similar to withdraw, not all contracts require the module functionality. This allows us to lower contract sizes for those that do not implement it. In doing this I also moved more module logic into the ado_base package to reduce code duplication.

# Implementation
Very similar approach as for withdraw was taken by adding a new `modules` feature. I also cleaned up the dependency statements for the ado_base package in other contracts by removing the library feature (which is no longer necessary).

I also added the `ado_type` as stored state in `ADOContract` as this now replaces the previous `ADOType` enum that was used to differentiate between the CW721 and CW20 for module validation.

# Testing

## Unit/Integration tests
I updated a few existing tests to ensure that the ADOContract was correctly instantiated. Since no new logic was added, no new tests are necessary.

## On-chain tests
None, as no new logic was added. I just verified that the module logic is only accessible from the cw20 and cw721 contracts.

# Future work
We will likely be moving more stuff into the ADOContract struct. I think PRIMITIVE_CONTRACT might be a good candidate.
