### PR TITLE
Apply ado_base package to mission contract

### DIFF
--- a/contracts/andromeda_mission/Cargo.toml
+++ b/contracts/andromeda_mission/Cargo.toml
@@ -28,7 +28,7 @@ schemars = "0.8.3"
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.26" }
 andromeda-protocol = { version = "0.1.0", path = "../../packages/andromeda_protocol" }
-ado-base = { path = "../../packages/ado_base", version = "0.1.0" }
+ado-base = { path = "../../packages/ado_base", version = "0.1.0", features=["instantiate"] }
 common = { version = "0.1.0", path = "../../packages/common" }
 
 [dev-dependencies]

--- a/contracts/andromeda_mission/src/state.rs
+++ b/contracts/andromeda_mission/src/state.rs
@@ -1,6 +1,5 @@
-use andromeda_protocol::{
-    communication::AndromedaMsg, error::ContractError, mission::MissionComponent,
-};
+use andromeda_protocol::mission::MissionComponent;
+use common::{ado_base::AndromedaMsg, error::ContractError};
 use cosmwasm_std::{to_binary, Addr, Coin, CosmosMsg, Order, ReplyOn, Storage, SubMsg, WasmMsg};
 use cw_storage_plus::{Bound, Item, Map};
 

--- a/packages/andromeda_protocol/src/factory.rs
+++ b/packages/andromeda_protocol/src/factory.rs
@@ -1,9 +1,5 @@
 use crate::modules::ModuleDefinition;
-use common::{
-    ado_base::{query_get, AndromedaMsg, AndromedaQuery},
-    error::ContractError,
-};
-use cosmwasm_std::{to_binary, QuerierWrapper, Storage};
+use common::ado_base::{AndromedaMsg, AndromedaQuery};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -52,15 +48,4 @@ pub enum QueryMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct AddressResponse {
     pub address: String,
-}
-
-pub fn get_ado_codeid(
-    storage: &dyn Storage,
-    querier: &QuerierWrapper,
-    name: &str,
-) -> Result<Option<u64>, ContractError> {
-    let factory_address = get_address(storage, querier, AndromedaContract::Factory)?;
-
-    let code_id: u64 = query_get(Some(to_binary(name)?), factory_address, querier)?;
-    Ok(Some(code_id))
 }

--- a/packages/andromeda_protocol/src/mission.rs
+++ b/packages/andromeda_protocol/src/mission.rs
@@ -1,9 +1,5 @@
-use crate::factory::get_ado_codeid;
-use common::{
-    ado_base::{AndromedaMsg, AndromedaQuery},
-    error::ContractError,
-};
-use cosmwasm_std::{Binary, CosmosMsg, QuerierWrapper, ReplyOn, Storage, SubMsg, WasmMsg};
+use common::ado_base::{AndromedaMsg, AndromedaQuery};
+use cosmwasm_std::Binary;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -14,45 +10,13 @@ pub struct MissionComponent {
     pub instantiate_msg: Binary,
 }
 
-// DEV NOTE: Redundant with CW721 modules, possibly merge the two implementations? Or maybe parts of it?
-/// A mission component is an ADO that is used in the flow of the mission
-impl MissionComponent {
-    /// Generates an instantiation message for the given Mission Component
-    /// Attaches the vector index of the Mission Component in order to map the Mission Component's name to its instantiated address
-    pub fn generate_instantiate_msg(
-        &self,
-        storage: &dyn Storage,
-        querier: &QuerierWrapper,
-        idx: u64,
-    ) -> Result<SubMsg, ContractError> {
-        match get_ado_codeid(storage, querier, &self.ado_type)? {
-            None => Err(ContractError::InvalidModule {
-                msg: Some(String::from(
-                    "ADO type provided does not have a valid Code Id",
-                )),
-            }),
-            Some(code_id) => Ok(SubMsg {
-                id: idx,
-                reply_on: ReplyOn::Always,
-                msg: CosmosMsg::Wasm(WasmMsg::Instantiate {
-                    admin: None,
-                    code_id,
-                    msg: self.instantiate_msg.clone(),
-                    funds: vec![],
-                    label: format!("Instantiate ADO: {}", self.ado_type.clone()),
-                }),
-                gas_limit: None,
-            }),
-        }
-    }
-}
-
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
     pub operators: Vec<String>,
     pub mission: Vec<MissionComponent>,
     pub xfer_ado_ownership: bool,
     pub name: String,
+    pub primitive_contract: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]


### PR DESCRIPTION
# Motivation
This is necessary to bring the mission contract up to date with the latest project structure.

# Implementation
I removed the duplicate instantiate msg generation logic and now use the instantiate msg logic of ADOContract.

# Testing

## Unit/Integration tests
None added here as this is a PR to fix build errors and merge changes. 

## On-chain tests
See above. 

# Future work
After this further features to the mission contracts can be added. 