### PR TITLE
Add module queries to ADOContract

### DIFF
--- a/packages/ado_base/src/modules/mod.rs
+++ b/packages/ado_base/src/modules/mod.rs
@@ -14,6 +14,7 @@ use common::{
 };
 
 pub mod hooks;
+pub mod query;
 
 impl<'a> ADOContract<'a> {
     pub fn register_modules(

--- a/packages/ado_base/src/modules/query.rs
+++ b/packages/ado_base/src/modules/query.rs
@@ -1,0 +1,111 @@
+use crate::{modules::ModuleInfoWithAddress, ADOContract};
+use common::error::ContractError;
+use cosmwasm_std::{Deps, Order, Uint64};
+use cw_storage_plus::Bound;
+
+impl<'a> ADOContract<'a> {
+    /// Queries a module by its id.
+    pub fn query_module(
+        &self,
+        deps: Deps,
+        id: Uint64,
+    ) -> Result<ModuleInfoWithAddress, ContractError> {
+        let id = id.to_string();
+        let module = self.module_info.load(deps.storage, &id)?;
+        let address = self.module_addr.load(deps.storage, &id)?.to_string();
+        Ok(ModuleInfoWithAddress { module, address })
+    }
+
+    /// Queries all of the module ids.
+    pub fn query_module_ids(&self, deps: Deps) -> Result<Vec<String>, ContractError> {
+        let module_idx = self.module_idx.may_load(deps.storage)?.unwrap_or(1);
+        let min = Some(Bound::Inclusive(1u64.to_le_bytes().to_vec()));
+        let module_ids: Result<Vec<String>, _> = self
+            .module_info
+            .keys(deps.storage, min, None, Order::Ascending)
+            .take(module_idx as usize)
+            .map(String::from_utf8)
+            .collect();
+        Ok(module_ids?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::modules::Module;
+    use common::ado_base::modules::InstantiateType;
+    use cosmwasm_std::{testing::mock_dependencies, Addr};
+
+    #[test]
+    fn test_query_module() {
+        let contract = ADOContract::default();
+        let mut deps = mock_dependencies(&[]);
+
+        contract
+            .owner
+            .save(deps.as_mut().storage, &Addr::unchecked("owner"))
+            .unwrap();
+
+        let module1 = Module {
+            module_type: "module_type1".to_string(),
+            instantiate: InstantiateType::Address("address1".to_string()),
+            is_mutable: true,
+        };
+
+        let module2 = Module {
+            module_type: "module_type2".to_string(),
+            instantiate: InstantiateType::Address("address2".to_string()),
+            is_mutable: true,
+        };
+
+        contract
+            .module_info
+            .save(deps.as_mut().storage, "1", &module1)
+            .unwrap();
+
+        contract
+            .module_addr
+            .save(deps.as_mut().storage, "1", &Addr::unchecked("address1"))
+            .unwrap();
+
+        contract
+            .module_info
+            .save(deps.as_mut().storage, "2", &module2)
+            .unwrap();
+
+        contract
+            .module_addr
+            .save(deps.as_mut().storage, "2", &Addr::unchecked("address2"))
+            .unwrap();
+
+        contract.module_idx.save(deps.as_mut().storage, &2).unwrap();
+
+        let res = contract
+            .query_module(deps.as_ref(), Uint64::from(1u64))
+            .unwrap();
+
+        assert_eq!(
+            ModuleInfoWithAddress {
+                module: module1,
+                address: "address1".to_string()
+            },
+            res
+        );
+
+        let res = contract
+            .query_module(deps.as_ref(), Uint64::from(2u64))
+            .unwrap();
+
+        assert_eq!(
+            ModuleInfoWithAddress {
+                module: module2,
+                address: "address2".to_string()
+            },
+            res
+        );
+
+        let res = contract.query_module_ids(deps.as_ref()).unwrap();
+        assert_eq!(vec![String::from("1"), String::from("2")], res);
+    }
+}

--- a/packages/ado_base/src/query.rs
+++ b/packages/ado_base/src/query.rs
@@ -33,6 +33,20 @@ impl<'a> ADOContract<'a> {
             AndromedaQuery::IsOperator { address } => {
                 encode_binary(&self.query_is_operator(deps, &address)?)
             }
+            AndromedaQuery::Module { id } => {
+                #[cfg(feature = "modules")]
+                return encode_binary(&self.query_module(deps, id)?);
+
+                #[cfg(not(feature = "modules"))]
+                return Err(ContractError::UnsupportedOperation {});
+            }
+            AndromedaQuery::ModuleIds {} => {
+                #[cfg(feature = "modules")]
+                return encode_binary(&self.query_module_ids(deps)?);
+
+                #[cfg(not(feature = "modules"))]
+                return Err(ContractError::UnsupportedOperation {});
+            }
         }
     }
 }

--- a/packages/common/src/ado_base/mod.rs
+++ b/packages/common/src/ado_base/mod.rs
@@ -55,6 +55,8 @@ pub enum AndromedaQuery {
     Owner {},
     Operators {},
     IsOperator { address: String },
+    Module { id: Uint64 },
+    ModuleIds {},
 }
 
 /// Helper enum for serialization


### PR DESCRIPTION
# Motivation
Currently it is not possible to get the module information from a given ADO directly. This makes it very difficult to get the id of each module which is necessary to alter and deregister them. 

# Implementation
I added a query to get a module and its address by its id, and a query to get all module ids. These two queries in conjunction give all the tools necessary to get the information of each module. 

# Testing

## Unit/Integration tests
I added a unit test for the queries. 

## On-chain tests
No since this is a simple change which has no reason why it shouldn't work. 

# Future work
We would like an integration test which registers/alters/deregisters and queries modules. 
