### PR TITLE
Add AndrAddress struct that directly queries the mission contract

### DIFF
--- a/contracts/andromeda_anchor/src/testing/tests.rs
+++ b/contracts/andromeda_anchor/src/testing/tests.rs
@@ -12,6 +12,7 @@ use common::{
         AndromedaMsg, AndromedaQuery,
     },
     error::ContractError,
+    mission::AndrAddress,
     withdraw::{Withdrawal, WithdrawalType},
 };
 use cosmwasm_std::{
@@ -623,7 +624,9 @@ fn test_withdraw_invalid_recipient() {
 
     let msg = ExecuteMsg::AndrReceive(AndromedaMsg::Withdraw {
         recipient: Some(Recipient::ADO(ADORecipient {
-            addr: recipient.to_owned(),
+            address: AndrAddress {
+                identifier: recipient.to_owned(),
+            },
             msg: None,
         })),
         tokens_to_withdraw: Some(vec![Withdrawal {

--- a/contracts/andromeda_crowdfund/src/contract.rs
+++ b/contracts/andromeda_crowdfund/src/contract.rs
@@ -14,7 +14,7 @@ use common::{
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    has_coins, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Order,
+    has_coins, Api, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Order,
     QuerierWrapper, QueryRequest, Reply, Response, Storage, SubMsg, Uint128, WasmMsg, WasmQuery,
 };
 use cw0::Expiration;
@@ -33,7 +33,7 @@ pub fn instantiate(
     CONFIG.save(
         deps.storage,
         &Config {
-            token_address: deps.api.addr_validate(&msg.token_address)?,
+            token_address: msg.token_address,
         },
     )?;
     ADOContract::default().instantiate(
@@ -161,7 +161,11 @@ fn execute_purchase(
     let config = CONFIG.load(deps.storage)?;
     let token_owner_res = query_owner_of(
         &deps.querier,
-        config.token_address.to_string(),
+        config.token_address.get_address_from_mission(
+            deps.api,
+            &deps.querier,
+            ADOContract::default().get_mission_contract(deps.storage)?,
+        )?,
         token_id.clone(),
     );
     require(
@@ -299,6 +303,7 @@ fn issue_refunds_and_burn_tokens(
     let burn_msgs = get_burn_messages(
         deps.storage,
         &deps.querier,
+        deps.api,
         env.contract.address.to_string(),
         limit,
     )?;
@@ -339,6 +344,7 @@ fn transfer_tokens_and_send_funds(
         let burn_msgs = get_burn_messages(
             deps.storage,
             &deps.querier,
+            deps.api,
             env.contract.address.to_string(),
             limit,
         )?;
@@ -394,7 +400,11 @@ fn transfer_tokens_and_send_funds(
         }
         rate_messages.extend(purchase.msgs);
         transfer_msgs.push(CosmosMsg::Wasm(WasmMsg::Execute {
-            contract_addr: config.token_address.to_string(),
+            contract_addr: config.token_address.get_address_from_mission(
+                deps.api,
+                &deps.querier,
+                ADOContract::default().get_mission_contract(deps.storage)?,
+            )?,
             msg: encode_binary(&Cw721ExecuteMsg::TransferNft {
                 recipient: purchaser,
                 token_id: purchase.token_id,
@@ -464,17 +474,23 @@ fn process_refund(
 fn get_burn_messages(
     storage: &dyn Storage,
     querier: &QuerierWrapper,
+    api: &dyn Api,
     address: String,
     limit: usize,
 ) -> Result<Vec<CosmosMsg>, ContractError> {
     let config = CONFIG.load(storage)?;
-    let tokens_to_burn = query_tokens(querier, config.token_address.to_string(), address, limit)?;
+    let token_address = config.token_address.get_address_from_mission(
+        api,
+        querier,
+        ADOContract::default().get_mission_contract(storage)?,
+    )?;
+    let tokens_to_burn = query_tokens(querier, token_address.clone(), address, limit)?;
 
     tokens_to_burn
         .into_iter()
         .map(|token_id| {
             Ok(CosmosMsg::Wasm(WasmMsg::Execute {
-                contract_addr: config.token_address.to_string(),
+                contract_addr: token_address.clone(),
                 funds: vec![],
                 msg: encode_binary(&Cw721ExecuteMsg::Burn { token_id })?,
             }))

--- a/contracts/andromeda_crowdfund/src/contract.rs
+++ b/contracts/andromeda_crowdfund/src/contract.rs
@@ -161,7 +161,7 @@ fn execute_purchase(
     let config = CONFIG.load(deps.storage)?;
     let token_owner_res = query_owner_of(
         &deps.querier,
-        config.token_address.get_address_from_mission(
+        config.token_address.get_address(
             deps.api,
             &deps.querier,
             ADOContract::default().get_mission_contract(deps.storage)?,
@@ -400,7 +400,7 @@ fn transfer_tokens_and_send_funds(
         }
         rate_messages.extend(purchase.msgs);
         transfer_msgs.push(CosmosMsg::Wasm(WasmMsg::Execute {
-            contract_addr: config.token_address.get_address_from_mission(
+            contract_addr: config.token_address.get_address(
                 deps.api,
                 &deps.querier,
                 ADOContract::default().get_mission_contract(deps.storage)?,
@@ -479,7 +479,7 @@ fn get_burn_messages(
     limit: usize,
 ) -> Result<Vec<CosmosMsg>, ContractError> {
     let config = CONFIG.load(storage)?;
-    let token_address = config.token_address.get_address_from_mission(
+    let token_address = config.token_address.get_address(
         api,
         querier,
         ADOContract::default().get_mission_contract(storage)?,

--- a/contracts/andromeda_crowdfund/src/state.rs
+++ b/contracts/andromeda_crowdfund/src/state.rs
@@ -1,5 +1,5 @@
-use common::ado_base::recipient::Recipient;
-use cosmwasm_std::{Addr, Coin, SubMsg, Uint128};
+use common::{ado_base::recipient::Recipient, mission::AndrAddress};
+use cosmwasm_std::{Coin, SubMsg, Uint128};
 use cw0::Expiration;
 use cw_storage_plus::{Item, Map};
 use schemars::JsonSchema;
@@ -32,7 +32,7 @@ pub struct Purchase {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
     /// The address of the token contract whose tokens are being sold.
-    pub token_address: Addr,
+    pub token_address: AndrAddress,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/andromeda_crowdfund/src/testing/tests.rs
+++ b/contracts/andromeda_crowdfund/src/testing/tests.rs
@@ -18,6 +18,7 @@ use common::{
     },
     encode_binary,
     error::ContractError,
+    mission::AndrAddress,
 };
 use cosmwasm_std::{
     coin, coins,
@@ -82,7 +83,9 @@ fn get_transfer_message(token_id: impl Into<String>, recipient: impl Into<String
 
 fn init(deps: DepsMut, modules: Option<Vec<Module>>) -> Response {
     let msg = InstantiateMsg {
-        token_address: MOCK_TOKEN_CONTRACT.to_owned(),
+        token_address: AndrAddress {
+            identifier: MOCK_TOKEN_CONTRACT.to_owned(),
+        },
         modules,
         primitive_contract: MOCK_PRIMITIVE_CONTRACT.to_owned(),
     };
@@ -113,7 +116,9 @@ fn test_instantiate() {
 
     assert_eq!(
         Config {
-            token_address: Addr::unchecked(MOCK_TOKEN_CONTRACT),
+            token_address: AndrAddress {
+                identifier: MOCK_TOKEN_CONTRACT.to_owned()
+            }
         },
         CONFIG.load(deps.as_mut().storage).unwrap()
     );

--- a/packages/andromeda_protocol/src/crowdfund.rs
+++ b/packages/andromeda_protocol/src/crowdfund.rs
@@ -1,4 +1,7 @@
-use common::ado_base::{modules::Module, recipient::Recipient, AndromedaMsg, AndromedaQuery};
+use common::{
+    ado_base::{modules::Module, recipient::Recipient, AndromedaMsg, AndromedaQuery},
+    mission::AndrAddress,
+};
 use cosmwasm_std::{Coin, Uint128};
 use cw0::Expiration;
 use schemars::JsonSchema;
@@ -6,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
-    pub token_address: String,
+    pub token_address: AndrAddress,
     pub modules: Option<Vec<Module>>,
     pub primitive_contract: String,
 }

--- a/packages/common/src/ado_base/recipient.rs
+++ b/packages/common/src/ado_base/recipient.rs
@@ -42,11 +42,7 @@ impl Recipient {
     ) -> Result<String, ContractError> {
         match &self {
             Recipient::Addr(string) => Ok(string.to_owned()),
-            Recipient::ADO(recip) => {
-                recip
-                    .address
-                    .get_address_from_mission(api, querier, mission_contract)
-            }
+            Recipient::ADO(recip) => recip.address.get_address(api, querier, mission_contract),
         }
     }
 

--- a/packages/common/src/lib.rs
+++ b/packages/common/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod ado_base;
 pub mod error;
+pub mod mission;
 pub mod primitive;
 pub mod response;
 #[cfg(test)]

--- a/packages/common/src/mission.rs
+++ b/packages/common/src/mission.rs
@@ -1,0 +1,74 @@
+use crate::{ado_base::query_get, encode_binary, error::ContractError};
+use cosmwasm_std::{Addr, Api, QuerierWrapper};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct AndrAddress {
+    /// Can be either an address or identifier of an ADO in a mission.
+    pub identifier: String,
+}
+
+impl AndrAddress {
+    /// Gets the address from the given identifier by attempting to validate it into an [`Addr`] and
+    /// then querying the mission contract if it fails.
+    pub fn get_address_from_mission(
+        &self,
+        api: &dyn Api,
+        querier: &QuerierWrapper,
+        mission_contract: Option<Addr>,
+    ) -> Result<String, ContractError> {
+        let addr = api.addr_validate(&self.identifier);
+        match addr {
+            Ok(addr) => Ok(addr.to_string()),
+            Err(_) => match mission_contract {
+                Some(mission_contract) => query_get::<String>(
+                    Some(encode_binary(&self.identifier)?),
+                    mission_contract.to_string(),
+                    querier,
+                ),
+                // TODO: Make error more descriptive.
+                None => Err(ContractError::InvalidAddress {}),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::mock_querier::{mock_dependencies_custom, MOCK_MISSION_CONTRACT};
+    use cosmwasm_std::testing::mock_dependencies;
+
+    #[test]
+    fn test_get_address_from_mission_not_mission() {
+        let deps = mock_dependencies(&[]);
+        let andr_address = AndrAddress {
+            identifier: "address".to_string(),
+        };
+        assert_eq!(
+            "address",
+            andr_address
+                .get_address_from_mission(deps.as_ref().api, &deps.as_ref().querier, None)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_get_address_from_mission_mission() {
+        let deps = mock_dependencies_custom(&[]);
+        let andr_address = AndrAddress {
+            identifier: "ab".to_string(),
+        };
+        assert_eq!(
+            "actual_address",
+            andr_address
+                .get_address_from_mission(
+                    deps.as_ref().api,
+                    &deps.as_ref().querier,
+                    Some(Addr::unchecked(MOCK_MISSION_CONTRACT)),
+                )
+                .unwrap()
+        );
+    }
+}

--- a/packages/common/src/mission.rs
+++ b/packages/common/src/mission.rs
@@ -12,7 +12,7 @@ pub struct AndrAddress {
 impl AndrAddress {
     /// Gets the address from the given identifier by attempting to validate it into an [`Addr`] and
     /// then querying the mission contract if it fails.
-    pub fn get_address_from_mission(
+    pub fn get_address(
         &self,
         api: &dyn Api,
         querier: &QuerierWrapper,
@@ -41,7 +41,7 @@ mod tests {
     use cosmwasm_std::testing::mock_dependencies;
 
     #[test]
-    fn test_get_address_from_mission_not_mission() {
+    fn test_get_address_not_mission() {
         let deps = mock_dependencies(&[]);
         let andr_address = AndrAddress {
             identifier: "address".to_string(),
@@ -49,13 +49,13 @@ mod tests {
         assert_eq!(
             "address",
             andr_address
-                .get_address_from_mission(deps.as_ref().api, &deps.as_ref().querier, None)
+                .get_address(deps.as_ref().api, &deps.as_ref().querier, None)
                 .unwrap()
         );
     }
 
     #[test]
-    fn test_get_address_from_mission_mission() {
+    fn test_get_address_mission() {
         let deps = mock_dependencies_custom(&[]);
         let andr_address = AndrAddress {
             identifier: "ab".to_string(),
@@ -63,7 +63,7 @@ mod tests {
         assert_eq!(
             "actual_address",
             andr_address
-                .get_address_from_mission(
+                .get_address(
                     deps.as_ref().api,
                     &deps.as_ref().querier,
                     Some(Addr::unchecked(MOCK_MISSION_CONTRACT)),


### PR DESCRIPTION
# Motivation
After my previous change https://github.com/andromedaprotocol/andromeda-contracts/pull/112 it quickly became apparent that we need to have the mission querying logic in all places that we reference the address of another ADO. To do this I decided on creating a new struct that will handle it called `AndrAddress`. Currently I've only replaced the `token_address` in the `CrowdFund` ADO with this new type, but if it is deemed to be a good solution it will be added everywhere. 

# Implementation
The struct was added to `common/src/mission.rs`, a new file. 

The struct is quite simple (see below). It implements a method `get_address_from_mission` that does the same mission querying logic that was added to `Recipient` in the last PR. 

```
#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
pub struct AndrAddress {
    /// Can be either an address or identifier of an ADO in a mission.
    pub identifier: String,
}
```

The reason why I prefer using a struct rather than a `String` with an associated function is twofold: 
1. From a user point of view using this struct makes it clear that the value passed can be a name OR an address. 
2. Programmatically it is impossible for us to forget to query the mission contract somewhere if we use a distinct type. If it was a string we could forget and only find out at runtime.

# Testing

## Unit/Integration tests
I modified the previously added unit tests in `Recipient` and added a few more in the new `common/src/mission.rs` file. 

## On-chain tests
Not yet as the mission contract is not ready for onchain tests. 

# Future work
If this solution is deemed good, we will likely replace `InstantiateType` in modules with `AndrAddress` and replace any other places where ado contracts are referenced with a String. 
