### PR TITLE
Replace Uint128 with Decimal for Rate + related refactors

### DIFF
--- a/contracts/andromeda_rates/src/contract.rs
+++ b/contracts/andromeda_rates/src/contract.rs
@@ -215,13 +215,14 @@ mod tests {
     use super::*;
     use crate::contract::{execute, instantiate, query};
     use andromeda_protocol::{
-        modules::{ADORate, Rate},
-        rates::{InstantiateMsg, PaymentsResponse, QueryMsg, RateInfo},
+        rates::{ADORate, InstantiateMsg, PaymentsResponse, QueryMsg, Rate, RateInfo},
         testing::mock_querier::{mock_dependencies_custom, MOCK_PRIMITIVE_CONTRACT},
     };
     use common::{ado_base::recipient::Recipient, encode_binary};
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-    use cosmwasm_std::{coin, coins, from_binary, BankMsg, Coin, CosmosMsg, Uint128, WasmMsg};
+    use cosmwasm_std::{
+        coin, coins, from_binary, BankMsg, Coin, CosmosMsg, Decimal, Uint128, WasmMsg,
+    };
     use cw20::Cw20ExecuteMsg;
 
     #[test]
@@ -232,7 +233,7 @@ mod tests {
         let info = mock_info(owner, &[]);
         let rates = vec![
             RateInfo {
-                rate: Rate::Percent(10u128.into()),
+                rate: Rate::from(Decimal::percent(10)),
                 is_additive: true,
                 description: Some("desc1".to_string()),
                 receivers: vec![Recipient::Addr("".into())],
@@ -274,7 +275,7 @@ mod tests {
         let info = mock_info(owner, &[]);
         let rates = vec![
             RateInfo {
-                rate: Rate::Percent(10u128.into()),
+                rate: Rate::from(Decimal::percent(10)),
                 is_additive: true,
                 description: Some("desc1".to_string()),
                 receivers: vec![Recipient::Addr("".into())],
@@ -319,7 +320,7 @@ mod tests {
                 receivers: vec![Recipient::Addr("1".into())],
             },
             RateInfo {
-                rate: Rate::Percent(10u128.into()),
+                rate: Rate::from(Decimal::percent(10)),
                 is_additive: false,
                 description: Some("desc1".to_string()),
                 receivers: vec![Recipient::Addr("2".into())],
@@ -405,7 +406,7 @@ mod tests {
                 receivers: vec![Recipient::Addr("1".into())],
             },
             RateInfo {
-                rate: Rate::Percent(10u128.into()),
+                rate: Rate::from(Decimal::percent(10)),
                 is_additive: false,
                 description: Some("desc1".to_string()),
                 receivers: vec![Recipient::Addr("2".into())],

--- a/packages/andromeda_protocol/src/cw721.rs
+++ b/packages/andromeda_protocol/src/cw721.rs
@@ -7,7 +7,7 @@ use cw721_base::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::modules::{common::calculate_fee, Rate};
+use crate::{modules::common::calculate_fee, rates::Rate};
 use common::{
     ado_base::{hooks::AndromedaHook, modules::Module, AndromedaMsg, AndromedaQuery},
     error::ContractError,

--- a/packages/andromeda_protocol/src/modules/mod.rs
+++ b/packages/andromeda_protocol/src/modules/mod.rs
@@ -3,96 +3,19 @@ pub mod common;
 pub mod hooks;
 pub mod receipt;
 
-use ::common::{
-    ado_base::query_get,
-    encode_binary,
-    error::ContractError,
-    primitive::{GetValueResponse, Primitive},
-    require,
-};
+use ::common::error::ContractError;
 
 use crate::modules::{
     address_list::AddressListModule,
     hooks::{HookResponse, MessageHooks},
     receipt::ReceiptModule,
 };
-use cosmwasm_std::{Coin, DepsMut, Env, MessageInfo, QuerierWrapper, StdResult, Storage, Uint128};
+use cosmwasm_std::{DepsMut, Env, MessageInfo, QuerierWrapper, StdResult, Storage};
 use cw_storage_plus::Item;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 pub const MODULES: Item<Modules> = Item::new("modules");
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub struct ADORate {
-    /// The address of the primitive contract.
-    pub address: String,
-    /// The key of the primitive in the primitive contract.
-    pub key: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-/// An enum used to define various types of fees
-pub enum Rate {
-    /// A flat rate fee
-    Flat(Coin),
-    /// A percentage fee (integer)
-    Percent(Uint128),
-    External(ADORate),
-}
-
-impl Rate {
-    /// Validates that a given rate is non-zero. It is expected that the Rate is not an
-    /// External Rate.
-    pub fn is_non_zero(&self) -> Result<bool, ContractError> {
-        match self {
-            Rate::Flat(coin) => Ok(coin.amount > Uint128::zero()),
-            Rate::Percent(rate) => Ok(rate > &Uint128::zero()),
-            Rate::External(_) => Err(ContractError::UnexpectedExternalRate {}),
-        }
-    }
-
-    /// Validates `self` and returns an "unwrapped" version of itself wherein if it is an External
-    /// Rate, the actual rate value is retrieved from the Primitive Contract.
-    pub fn validate(&self, querier: &QuerierWrapper) -> Result<Rate, ContractError> {
-        let rate = self.clone().get_rate(querier)?;
-        require(rate.is_non_zero()?, ContractError::InvalidRate {})?;
-
-        if let Rate::Percent(rate) = rate {
-            require(
-                rate <= Uint128::from(100u128),
-                ContractError::InvalidRate {},
-            )?;
-        }
-
-        Ok(rate)
-    }
-
-    /// If `self` is Flat or Percent it returns itself. Otherwise it queries the primitive contract
-    /// and retrieves the actual Flat or Percent rate.
-    fn get_rate(self, querier: &QuerierWrapper) -> Result<Rate, ContractError> {
-        match self {
-            Rate::Flat(_) => Ok(self),
-            Rate::Percent(_) => Ok(self),
-            Rate::External(ado_rate) => {
-                let response: GetValueResponse = query_get(
-                    Some(encode_binary(&ado_rate.key)?),
-                    ado_rate.address,
-                    querier,
-                )?;
-                match response.value {
-                    Primitive::Coin(coin) => Ok(Rate::Flat(coin)),
-                    Primitive::Uint128(value) => Ok(Rate::Percent(value)),
-                    _ => Err(ContractError::ParsingError {
-                        err: "Stored rate is not a coin or Uint128".to_string(),
-                    }),
-                }
-            }
-        }
-    }
-}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -265,33 +188,4 @@ pub fn generate_instantiate_msgs(
     }
 
     Ok(resp)
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::testing::mock_querier::{mock_dependencies_custom, MOCK_PRIMITIVE_CONTRACT};
-    use cosmwasm_std::coin;
-
-    use super::*;
-
-    #[test]
-    fn test_validate_external_rate() {
-        let mut deps = mock_dependencies_custom(&[]);
-
-        let rate = Rate::External(ADORate {
-            address: MOCK_PRIMITIVE_CONTRACT.to_string(),
-            key: Some("percent".to_string()),
-        });
-        let validated_rate = rate.validate(&deps.as_mut().querier).unwrap();
-        let expected_rate = Rate::Percent(1u128.into());
-        assert_eq!(expected_rate, validated_rate);
-
-        let rate = Rate::External(ADORate {
-            address: MOCK_PRIMITIVE_CONTRACT.to_string(),
-            key: Some("flat".to_string()),
-        });
-        let validated_rate = rate.validate(&deps.as_mut().querier).unwrap();
-        let expected_rate = Rate::Flat(coin(1u128, "uusd"));
-        assert_eq!(expected_rate, validated_rate);
-    }
 }

--- a/packages/andromeda_protocol/src/rates.rs
+++ b/packages/andromeda_protocol/src/rates.rs
@@ -1,16 +1,17 @@
-use crate::modules::Rate;
 use common::{
     ado_base::{
         hooks::{AndromedaHook, OnFundsTransferResponse},
+        query_get,
         recipient::Recipient,
         AndromedaMsg, AndromedaQuery,
     },
     encode_binary,
     error::ContractError,
-    Funds,
+    primitive::{GetValueResponse, Primitive},
+    require, Funds,
 };
 use cosmwasm_std::{
-    BankMsg, Coin, CosmosMsg, QuerierWrapper, QueryRequest, SubMsg, Uint128, WasmQuery,
+    BankMsg, Coin, CosmosMsg, Decimal, QuerierWrapper, QueryRequest, SubMsg, Uint128, WasmQuery,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -50,6 +51,87 @@ pub struct RateInfo {
     pub is_additive: bool,
     pub description: Option<String>,
     pub receivers: Vec<Recipient>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct ADORate {
+    /// The address of the primitive contract.
+    pub address: String,
+    /// The key of the primitive in the primitive contract.
+    pub key: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+/// An enum used to define various types of fees
+pub enum Rate {
+    /// A flat rate fee
+    Flat(Coin),
+    /// A percentage fee
+    Percent(PercentRate),
+    External(ADORate),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+// This is added such that both Rate::Flat and Rate::Percent have the same level of nesting which
+// makes it easier to work with on the frontend.
+pub struct PercentRate {
+    pub percent: Decimal,
+}
+
+impl From<Decimal> for Rate {
+    fn from(decimal: Decimal) -> Self {
+        Rate::Percent(PercentRate { percent: decimal })
+    }
+}
+
+impl Rate {
+    /// Validates that a given rate is non-zero. It is expected that the Rate is not an
+    /// External Rate.
+    pub fn is_non_zero(&self) -> Result<bool, ContractError> {
+        match self {
+            Rate::Flat(coin) => Ok(!coin.amount.is_zero()),
+            Rate::Percent(PercentRate { percent }) => Ok(!percent.is_zero()),
+            Rate::External(_) => Err(ContractError::UnexpectedExternalRate {}),
+        }
+    }
+
+    /// Validates `self` and returns an "unwrapped" version of itself wherein if it is an External
+    /// Rate, the actual rate value is retrieved from the Primitive Contract.
+    pub fn validate(&self, querier: &QuerierWrapper) -> Result<Rate, ContractError> {
+        let rate = self.clone().get_rate(querier)?;
+        require(rate.is_non_zero()?, ContractError::InvalidRate {})?;
+
+        if let Rate::Percent(PercentRate { percent }) = rate {
+            require(percent <= Decimal::one(), ContractError::InvalidRate {})?;
+        }
+
+        Ok(rate)
+    }
+
+    /// If `self` is Flat or Percent it returns itself. Otherwise it queries the primitive contract
+    /// and retrieves the actual Flat or Percent rate.
+    fn get_rate(self, querier: &QuerierWrapper) -> Result<Rate, ContractError> {
+        match self {
+            Rate::Flat(_) => Ok(self),
+            Rate::Percent(_) => Ok(self),
+            Rate::External(ado_rate) => {
+                let response: GetValueResponse = query_get(
+                    Some(encode_binary(&ado_rate.key)?),
+                    ado_rate.address,
+                    querier,
+                )?;
+                match response.value {
+                    Primitive::Coin(coin) => Ok(Rate::Flat(coin)),
+                    Primitive::Decimal(value) => Ok(Rate::from(value)),
+                    _ => Err(ContractError::ParsingError {
+                        err: "Stored rate is not a coin or Decimal".to_string(),
+                    }),
+                }
+            }
+        }
+    }
 }
 
 /// An attribute struct used for any events that involve a payment
@@ -111,4 +193,33 @@ pub fn on_required_payments(
     }))?;
 
     Ok(res)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::testing::mock_querier::{mock_dependencies_custom, MOCK_PRIMITIVE_CONTRACT};
+    use cosmwasm_std::coin;
+
+    use super::*;
+
+    #[test]
+    fn test_validate_external_rate() {
+        let mut deps = mock_dependencies_custom(&[]);
+
+        let rate = Rate::External(ADORate {
+            address: MOCK_PRIMITIVE_CONTRACT.to_string(),
+            key: Some("percent".to_string()),
+        });
+        let validated_rate = rate.validate(&deps.as_mut().querier).unwrap();
+        let expected_rate = Rate::from(Decimal::percent(1));
+        assert_eq!(expected_rate, validated_rate);
+
+        let rate = Rate::External(ADORate {
+            address: MOCK_PRIMITIVE_CONTRACT.to_string(),
+            key: Some("flat".to_string()),
+        });
+        let validated_rate = rate.validate(&deps.as_mut().querier).unwrap();
+        let expected_rate = Rate::Flat(coin(1u128, "uusd"));
+        assert_eq!(expected_rate, validated_rate);
+    }
 }

--- a/packages/andromeda_protocol/src/testing/mock_querier.rs
+++ b/packages/andromeda_protocol/src/testing/mock_querier.rs
@@ -477,7 +477,7 @@ impl WasmMockQuerier {
                 let msg_response = match name.as_str() {
                     "percent" => GetValueResponse {
                         name,
-                        value: Primitive::Uint128(1u128.into()),
+                        value: Primitive::Decimal(Decimal::percent(1)),
                     },
                     "flat" => GetValueResponse {
                         name,

--- a/packages/common/src/primitive.rs
+++ b/packages/common/src/primitive.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Coin, StdError, Uint128};
+use cosmwasm_std::{Coin, Decimal, StdError, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -21,6 +21,7 @@ impl fmt::Display for AndromedaContract {
 #[serde(rename_all = "snake_case")]
 pub enum Primitive {
     Uint128(Uint128),
+    Decimal(Decimal),
     Coin(Coin),
     String(String),
     Bool(bool),


### PR DESCRIPTION
# Motivation
We already changed the splitter percentage splits to use `Decimal` instead of `Uint128` so this change has the same motivations as that one. I also moved the `Rate` struct to `rates.rs` to keep all related structs in a single place. Lastly I replaced `Rate::Percent(Uint128)` with `Rate::Percent(PercentRate)` where `PercentRate` is defined as
```
struct PercentRate {
    percent: Decimal
}
```
This was done by request of the frontend team to have both `Rate::Flat` and `Rate::Percent` have the same level of nesting. 

# Implementation
Fairly routine implementation which involved updating tests and changing the `calculate_fee` function. 

# Testing

## Unit/Integration tests
I updated the existing tests.

## On-chain tests
No as it is a pretty trivial change. 

# Future work
In terms of moving things around we will want a new home for the other rate related functions like `calculate_fee`. We will also want to continue replacing instances of `Uint128` with `Decimal` where applicable.