### PR TITLE
Replace InstantiateType with AndrAddress in Modules

### DIFF
--- a/contracts/andromeda_addresslist/src/contract.rs
+++ b/contracts/andromeda_addresslist/src/contract.rs
@@ -31,7 +31,6 @@ pub fn instantiate(
     ADOContract::default().instantiate(
         deps.storage,
         deps.api,
-        &deps.querier,
         info,
         BaseInstantiateMsg {
             ado_type: "address_list".to_string(),

--- a/contracts/andromeda_anchor/src/contract.rs
+++ b/contracts/andromeda_anchor/src/contract.rs
@@ -51,7 +51,6 @@ pub fn instantiate(
     ADOContract::default().instantiate(
         deps.storage,
         deps.api,
-        &deps.querier,
         info,
         BaseInstantiateMsg {
             ado_type: "anchor".to_string(),

--- a/contracts/andromeda_astroport/src/contract.rs
+++ b/contracts/andromeda_astroport/src/contract.rs
@@ -45,7 +45,6 @@ pub fn instantiate(
     ADOContract::default().instantiate(
         deps.storage,
         deps.api,
-        &deps.querier,
         info,
         BaseInstantiateMsg {
             ado_type: "astroport".to_string(),

--- a/contracts/andromeda_auction/src/contract.rs
+++ b/contracts/andromeda_auction/src/contract.rs
@@ -32,7 +32,6 @@ pub fn instantiate(
     ADOContract::default().instantiate(
         deps.storage,
         deps.api,
-        &deps.querier,
         info,
         BaseInstantiateMsg {
             ado_type: "auction".to_string(),

--- a/contracts/andromeda_crowdfund/src/contract.rs
+++ b/contracts/andromeda_crowdfund/src/contract.rs
@@ -15,7 +15,7 @@ use common::{
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     has_coins, Api, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Order,
-    QuerierWrapper, QueryRequest, Reply, Response, Storage, SubMsg, Uint128, WasmMsg, WasmQuery,
+    QuerierWrapper, QueryRequest, Response, Storage, SubMsg, Uint128, WasmMsg, WasmQuery,
 };
 use cw0::Expiration;
 use cw721::{OwnerOfResponse, TokensResponse};
@@ -39,7 +39,6 @@ pub fn instantiate(
     ADOContract::default().instantiate(
         deps.storage,
         deps.api,
-        &deps.querier,
         info,
         BaseInstantiateMsg {
             ado_type: "crowdfund".to_string(),
@@ -48,11 +47,6 @@ pub fn instantiate(
             primitive_contract: Some(msg.primitive_contract),
         },
     )
-}
-
-#[cfg_attr(not(feature = "library"), entry_point)]
-pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractError> {
-    ADOContract::default().handle_module_reply(deps, msg)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -187,6 +181,7 @@ fn execute_purchase(
     )?;
     let (msgs, _events, remainder) = ADOContract::default().on_funds_transfer(
         deps.storage,
+        deps.api,
         deps.querier,
         sender.clone(),
         Funds::Native(state.price.clone()),

--- a/contracts/andromeda_crowdfund/src/testing/tests.rs
+++ b/contracts/andromeda_crowdfund/src/testing/tests.rs
@@ -111,6 +111,7 @@ fn test_instantiate() {
     assert_eq!(
         Response::new()
             .add_attribute("action", "register_module")
+            .add_attribute("module_idx", "1")
             .add_attribute("method", "instantiate")
             .add_attribute("type", "crowdfund"),
         res

--- a/contracts/andromeda_crowdfund/src/testing/tests.rs
+++ b/contracts/andromeda_crowdfund/src/testing/tests.rs
@@ -13,7 +13,7 @@ use andromeda_protocol::{
 };
 use common::{
     ado_base::{
-        modules::{InstantiateType, Module, RATES},
+        modules::{Module, RATES},
         recipient::Recipient,
     },
     encode_binary,
@@ -100,7 +100,9 @@ fn test_instantiate() {
 
     let modules = vec![Module {
         module_type: RATES.to_owned(),
-        instantiate: InstantiateType::Address(MOCK_RATES_CONTRACT.to_owned()),
+        address: AndrAddress {
+            identifier: MOCK_RATES_CONTRACT.to_owned(),
+        },
         is_mutable: false,
     }];
 
@@ -408,7 +410,9 @@ fn test_purchase_not_enough_for_price() {
     let mut deps = mock_dependencies_custom(&[]);
     let modules = vec![Module {
         module_type: RATES.to_owned(),
-        instantiate: InstantiateType::Address(MOCK_RATES_CONTRACT.to_owned()),
+        address: AndrAddress {
+            identifier: MOCK_RATES_CONTRACT.to_owned(),
+        },
         is_mutable: false,
     }];
     init(deps.as_mut(), Some(modules));
@@ -443,7 +447,9 @@ fn test_purchase_not_enough_for_tax() {
     let mut deps = mock_dependencies_custom(&[]);
     let modules = vec![Module {
         module_type: RATES.to_owned(),
-        instantiate: InstantiateType::Address(MOCK_RATES_CONTRACT.to_owned()),
+        address: AndrAddress {
+            identifier: MOCK_RATES_CONTRACT.to_owned(),
+        },
         is_mutable: false,
     }];
     init(deps.as_mut(), Some(modules));
@@ -478,7 +484,9 @@ fn test_multiple_purchases() {
     let mut deps = mock_dependencies_custom(&[]);
     let modules = vec![Module {
         module_type: RATES.to_owned(),
-        instantiate: InstantiateType::Address(MOCK_RATES_CONTRACT.to_owned()),
+        address: AndrAddress {
+            identifier: MOCK_RATES_CONTRACT.to_owned(),
+        },
         is_mutable: false,
     }];
     init(deps.as_mut(), Some(modules));
@@ -583,7 +591,9 @@ fn test_integration_conditions_not_met() {
     let mut deps = mock_dependencies_custom(&[]);
     let modules = vec![Module {
         module_type: RATES.to_owned(),
-        instantiate: InstantiateType::Address(MOCK_RATES_CONTRACT.to_owned()),
+        address: AndrAddress {
+            identifier: MOCK_RATES_CONTRACT.to_owned(),
+        },
         is_mutable: false,
     }];
     init(deps.as_mut(), Some(modules));
@@ -718,7 +728,9 @@ fn test_integration_conditions_met() {
     deps.querier.contract_address = MOCK_CONDITIONS_MET_CONTRACT.to_string();
     let modules = vec![Module {
         module_type: RATES.to_owned(),
-        instantiate: InstantiateType::Address(MOCK_RATES_CONTRACT.to_owned()),
+        address: AndrAddress {
+            identifier: MOCK_RATES_CONTRACT.to_owned(),
+        },
         is_mutable: false,
     }];
     init(deps.as_mut(), Some(modules));

--- a/contracts/andromeda_cw20/src/contract.rs
+++ b/contracts/andromeda_cw20/src/contract.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    from_binary, to_binary, Addr, Api, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Reply,
+    from_binary, to_binary, Addr, Api, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
     Response, StdResult, Storage, SubMsg, Uint128, WasmMsg,
 };
 
@@ -35,7 +35,6 @@ pub fn instantiate(
     let resp = contract.instantiate(
         deps.storage,
         deps.api,
-        &deps.querier,
         info.clone(),
         BaseInstantiateMsg {
             ado_type: "cw20".to_string(),
@@ -52,11 +51,6 @@ pub fn instantiate(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractError> {
-    ADOContract::default().handle_module_reply(deps, msg)
-}
-
-#[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
     deps: DepsMut,
     env: Env,
@@ -66,6 +60,7 @@ pub fn execute(
     let contract = ADOContract::default();
     contract.module_hook::<Response>(
         deps.storage,
+        deps.api,
         deps.querier,
         AndromedaHook::OnExecute {
             sender: info.sender.to_string(),
@@ -97,6 +92,7 @@ fn execute_transfer(
 ) -> Result<Response, ContractError> {
     let (msgs, events, remainder) = ADOContract::default().on_funds_transfer(
         deps.storage,
+        deps.api,
         deps.querier,
         info.sender.to_string(),
         Funds::Cw20(Cw20Coin {
@@ -174,6 +170,7 @@ fn execute_send(
 ) -> Result<Response, ContractError> {
     let (msgs, events, remainder) = ADOContract::default().on_funds_transfer(
         deps.storage,
+        deps.api,
         deps.querier,
         info.sender.to_string(),
         Funds::Cw20(Cw20Coin {

--- a/contracts/andromeda_cw20/src/testing/tests.rs
+++ b/contracts/andromeda_cw20/src/testing/tests.rs
@@ -1,27 +1,28 @@
 use crate::contract::{execute, instantiate};
-use ado_base::ADOContract;
 use andromeda_protocol::{
-    address_list::InstantiateMsg as AddressListInstantiateMsg,
     cw20::{ExecuteMsg, InstantiateMsg},
-    rates::InstantiateMsg as RatesInstantiateMsg,
-    receipt::{ExecuteMsg as ReceiptExecuteMsg, InstantiateMsg as ReceiptInstantiateMsg, Receipt},
+    receipt::{ExecuteMsg as ReceiptExecuteMsg, Receipt},
     testing::mock_querier::{
         mock_dependencies_custom, MOCK_ADDRESSLIST_CONTRACT, MOCK_PRIMITIVE_CONTRACT,
         MOCK_RATES_CONTRACT, MOCK_RECEIPT_CONTRACT,
     },
 };
 use common::{
-    ado_base::modules::{InstantiateType, Module, ADDRESS_LIST, RATES, RECEIPT},
+    ado_base::modules::{Module, ADDRESS_LIST, RATES, RECEIPT},
     error::ContractError,
+    mission::AndrAddress,
 };
 use cosmwasm_std::{
     testing::{mock_env, mock_info},
-    to_binary, Addr, CosmosMsg, Event, ReplyOn, Response, StdError, SubMsg, Uint128, WasmMsg,
+    to_binary, Addr, CosmosMsg, Event, Response, StdError, SubMsg, Uint128, WasmMsg,
 };
 use cw20::{Cw20Coin, Cw20ReceiveMsg};
 use cw20_base::state::BALANCES;
 
-#[test]
+/*#
+ *
+ * TODO: Remove when we are happy with InstantiateType replacement.
+ * [test]
 fn test_instantiate_modules() {
     let receipt_msg = to_binary(&ReceiptInstantiateMsg {
         minter: "minter".to_string(),
@@ -132,24 +133,30 @@ fn test_instantiate_modules() {
             .add_submessages(msgs),
         res
     );
-}
+}*/
 
 #[test]
 fn test_transfer() {
     let modules: Vec<Module> = vec![
         Module {
             module_type: RECEIPT.to_owned(),
-            instantiate: InstantiateType::Address(MOCK_RECEIPT_CONTRACT.into()),
+            address: AndrAddress {
+                identifier: MOCK_RECEIPT_CONTRACT.to_owned(),
+            },
             is_mutable: false,
         },
         Module {
             module_type: RATES.to_owned(),
-            instantiate: InstantiateType::Address(MOCK_RATES_CONTRACT.into()),
+            address: AndrAddress {
+                identifier: MOCK_RATES_CONTRACT.to_owned(),
+            },
             is_mutable: false,
         },
         Module {
             module_type: ADDRESS_LIST.to_owned(),
-            instantiate: InstantiateType::Address(MOCK_ADDRESSLIST_CONTRACT.into()),
+            address: AndrAddress {
+                identifier: MOCK_ADDRESSLIST_CONTRACT.to_owned(),
+            },
             is_mutable: false,
         },
     ];
@@ -258,17 +265,23 @@ fn test_send() {
     let modules: Vec<Module> = vec![
         Module {
             module_type: RECEIPT.to_owned(),
-            instantiate: InstantiateType::Address(MOCK_RECEIPT_CONTRACT.into()),
+            address: AndrAddress {
+                identifier: MOCK_RECEIPT_CONTRACT.to_owned(),
+            },
             is_mutable: false,
         },
         Module {
             module_type: RATES.to_owned(),
-            instantiate: InstantiateType::Address(MOCK_RATES_CONTRACT.into()),
+            address: AndrAddress {
+                identifier: MOCK_RATES_CONTRACT.to_owned(),
+            },
             is_mutable: false,
         },
         Module {
             module_type: ADDRESS_LIST.to_owned(),
-            instantiate: InstantiateType::Address(MOCK_ADDRESSLIST_CONTRACT.into()),
+            address: AndrAddress {
+                identifier: MOCK_ADDRESSLIST_CONTRACT.to_owned(),
+            },
             is_mutable: false,
         },
     ];

--- a/contracts/andromeda_cw20/src/testing/tests.rs
+++ b/contracts/andromeda_cw20/src/testing/tests.rs
@@ -182,8 +182,11 @@ fn test_transfer() {
     assert_eq!(
         Response::new()
             .add_attribute("action", "register_module")
+            .add_attribute("module_idx", "1")
             .add_attribute("action", "register_module")
+            .add_attribute("module_idx", "2")
             .add_attribute("action", "register_module")
+            .add_attribute("module_idx", "3")
             .add_attribute("method", "instantiate")
             .add_attribute("type", "cw20"),
         res
@@ -307,8 +310,11 @@ fn test_send() {
     assert_eq!(
         Response::new()
             .add_attribute("action", "register_module")
+            .add_attribute("module_idx", "1")
             .add_attribute("action", "register_module")
+            .add_attribute("module_idx", "2")
             .add_attribute("action", "register_module")
+            .add_attribute("module_idx", "3")
             .add_attribute("method", "instantiate")
             .add_attribute("type", "cw20"),
         res

--- a/contracts/andromeda_cw721/src/testing/mod.rs
+++ b/contracts/andromeda_cw721/src/testing/mod.rs
@@ -1,27 +1,25 @@
 use cosmwasm_std::{
     attr, coin, coins, from_binary,
     testing::{mock_dependencies, mock_env, mock_info},
-    to_binary, Addr, Coin, CosmosMsg, DepsMut, Env, Event, ReplyOn, Response, StdError, SubMsg,
-    Uint128, WasmMsg,
+    to_binary, Addr, Coin, CosmosMsg, DepsMut, Env, Event, Response, StdError, SubMsg, Uint128,
+    WasmMsg,
 };
 
-use ado_base::ADOContract;
 use common::{
     ado_base::{
         hooks::{AndromedaHook, OnFundsTransferResponse},
-        modules::{InstantiateType, Module, ADDRESS_LIST, OFFERS, RATES, RECEIPT},
+        modules::{Module, ADDRESS_LIST, OFFERS, RATES, RECEIPT},
     },
     error::ContractError,
+    mission::AndrAddress,
     Funds,
 };
 
 use crate::contract::*;
 use andromeda_protocol::{
-    address_list::InstantiateMsg as AddressListInstantiateMsg,
     cw721::{ExecuteMsg, InstantiateMsg, QueryMsg, TokenExtension, TransferAgreement},
     cw721_offers::ExecuteMsg as OffersExecuteMsg,
-    rates::InstantiateMsg as RatesInstantiateMsg,
-    receipt::{ExecuteMsg as ReceiptExecuteMsg, InstantiateMsg as ReceiptInstantiateMsg, Receipt},
+    receipt::{ExecuteMsg as ReceiptExecuteMsg, Receipt},
     testing::mock_querier::{
         bank_sub_msg, mock_dependencies_custom, MOCK_ADDRESSLIST_CONTRACT, MOCK_OFFERS_CONTRACT,
         MOCK_PRIMITIVE_CONTRACT, MOCK_RATES_CONTRACT, MOCK_RATES_RECIPIENT, MOCK_RECEIPT_CONTRACT,
@@ -58,7 +56,9 @@ fn mint_token(deps: DepsMut, env: Env, token_id: String, owner: String, extensio
     execute(deps, env, info, ExecuteMsg::Mint(Box::new(mint_msg))).unwrap();
 }
 
-#[test]
+/*
+ * TODO: Remove when we are happy with IstantiateType replacement.
+ * #[test]
 fn test_instantiate_modules() {
     let receipt_msg = to_binary(&ReceiptInstantiateMsg {
         minter: "minter".to_string(),
@@ -164,7 +164,7 @@ fn test_instantiate_modules() {
             .add_submessages(msgs),
         res
     );
-}
+}*/
 
 #[test]
 fn test_transfer_nft() {
@@ -512,17 +512,23 @@ fn test_modules() {
     let modules: Vec<Module> = vec![
         Module {
             module_type: RECEIPT.to_owned(),
-            instantiate: InstantiateType::Address(MOCK_RECEIPT_CONTRACT.into()),
+            address: AndrAddress {
+                identifier: MOCK_RECEIPT_CONTRACT.to_owned(),
+            },
             is_mutable: false,
         },
         Module {
             module_type: RATES.to_owned(),
-            instantiate: InstantiateType::Address(MOCK_RATES_CONTRACT.into()),
+            address: AndrAddress {
+                identifier: MOCK_RATES_CONTRACT.to_owned(),
+            },
             is_mutable: false,
         },
         Module {
             module_type: ADDRESS_LIST.to_owned(),
-            instantiate: InstantiateType::Address(MOCK_ADDRESSLIST_CONTRACT.into()),
+            address: AndrAddress {
+                identifier: MOCK_ADDRESSLIST_CONTRACT.to_owned(),
+            },
             is_mutable: false,
         },
     ];
@@ -644,7 +650,9 @@ fn test_modules() {
 fn test_transfer_with_offer() {
     let modules: Vec<Module> = vec![Module {
         module_type: OFFERS.to_owned(),
-        instantiate: InstantiateType::Address(MOCK_OFFERS_CONTRACT.into()),
+        address: AndrAddress {
+            identifier: MOCK_OFFERS_CONTRACT.to_owned(),
+        },
         is_mutable: false,
     }];
 

--- a/contracts/andromeda_cw721_offers/src/contract.rs
+++ b/contracts/andromeda_cw721_offers/src/contract.rs
@@ -43,7 +43,6 @@ pub fn instantiate(
     ADOContract::default().instantiate(
         deps.storage,
         deps.api,
-        &deps.querier,
         info,
         BaseInstantiateMsg {
             ado_type: "cw721_offers".to_string(),

--- a/contracts/andromeda_factory/src/contract.rs
+++ b/contracts/andromeda_factory/src/contract.rs
@@ -35,7 +35,6 @@ pub fn instantiate(
     ADOContract::default().instantiate(
         deps.storage,
         deps.api,
-        &deps.querier,
         info,
         BaseInstantiateMsg {
             ado_type: "factory".to_string(),

--- a/contracts/andromeda_mirror_wrapped_cdp/src/contract.rs
+++ b/contracts/andromeda_mirror_wrapped_cdp/src/contract.rs
@@ -57,7 +57,6 @@ pub fn instantiate(
     contract.instantiate(
         deps.storage,
         deps.api,
-        &deps.querier,
         info,
         BaseInstantiateMsg {
             ado_type: "mirror".to_string(),

--- a/contracts/andromeda_mission/src/contract.rs
+++ b/contracts/andromeda_mission/src/contract.rs
@@ -44,7 +44,6 @@ pub fn instantiate(
         .instantiate(
             deps.storage,
             deps.api,
-            &deps.querier,
             info,
             BaseInstantiateMsg {
                 ado_type: "mission".to_string(),

--- a/contracts/andromeda_primitive/src/contract.rs
+++ b/contracts/andromeda_primitive/src/contract.rs
@@ -30,7 +30,6 @@ pub fn instantiate(
     ADOContract::default().instantiate(
         deps.storage,
         deps.api,
-        &deps.querier,
         info,
         BaseInstantiateMsg {
             ado_type: "primitive".to_string(),

--- a/contracts/andromeda_rates/src/contract.rs
+++ b/contracts/andromeda_rates/src/contract.rs
@@ -39,7 +39,6 @@ pub fn instantiate(
     ADOContract::default().instantiate(
         deps.storage,
         deps.api,
-        &deps.querier,
         info,
         BaseInstantiateMsg {
             ado_type: "rates".to_string(),

--- a/contracts/andromeda_receipt/src/contract.rs
+++ b/contracts/andromeda_receipt/src/contract.rs
@@ -36,7 +36,6 @@ pub fn instantiate(
     ADOContract::default().instantiate(
         deps.storage,
         deps.api,
-        &deps.querier,
         info,
         BaseInstantiateMsg {
             ado_type: "receipt".to_string(),

--- a/contracts/andromeda_splitter/src/contract.rs
+++ b/contracts/andromeda_splitter/src/contract.rs
@@ -55,7 +55,6 @@ pub fn instantiate(
     let res = ADOContract::default().instantiate(
         deps.storage,
         deps.api,
-        &deps.querier,
         info,
         BaseInstantiateMsg {
             ado_type: "splitter".to_string(),

--- a/contracts/andromeda_swapper/src/contract.rs
+++ b/contracts/andromeda_swapper/src/contract.rs
@@ -2,13 +2,11 @@ use crate::state::SWAPPER_IMPL_ADDR;
 use ado_base::ADOContract;
 use andromeda_protocol::swapper::{
     query_balance, query_token_balance, AssetInfo, Cw20HookMsg, ExecuteMsg, InstantiateMsg,
-    MigrateMsg, QueryMsg, SwapperCw20HookMsg, SwapperImplCw20HookMsg, SwapperImplExecuteMsg,
-    SwapperMsg,
+    InstantiateType, MigrateMsg, QueryMsg, SwapperCw20HookMsg, SwapperImplCw20HookMsg,
+    SwapperImplExecuteMsg, SwapperMsg,
 };
 use common::{
-    ado_base::{
-        modules::InstantiateType, recipient::Recipient, InstantiateMsg as BaseInstantiateMsg,
-    },
+    ado_base::{recipient::Recipient, InstantiateMsg as BaseInstantiateMsg},
     encode_binary,
     error::ContractError,
     require,
@@ -37,7 +35,6 @@ pub fn instantiate(
     let resp = contract.instantiate(
         deps.storage,
         deps.api,
-        &deps.querier,
         info,
         BaseInstantiateMsg {
             ado_type: "swapper".to_string(),

--- a/contracts/andromeda_swapper/src/testing/tests.rs
+++ b/contracts/andromeda_swapper/src/testing/tests.rs
@@ -1,18 +1,15 @@
 use crate::contract::{execute, instantiate};
 use andromeda_protocol::{
     swapper::{
-        AssetInfo, Cw20HookMsg, ExecuteMsg, InstantiateMsg, SwapperCw20HookMsg, SwapperImpl,
-        SwapperImplCw20HookMsg, SwapperImplExecuteMsg, SwapperMsg,
+        AssetInfo, Cw20HookMsg, ExecuteMsg, InstantiateMsg, InstantiateType, SwapperCw20HookMsg,
+        SwapperImpl, SwapperImplCw20HookMsg, SwapperImplExecuteMsg, SwapperMsg,
     },
     testing::mock_querier::{
         mock_dependencies_custom, MOCK_ASTROPORT_WRAPPER_CONTRACT, MOCK_CW20_CONTRACT,
         MOCK_CW20_CONTRACT2,
     },
 };
-use common::{
-    ado_base::{modules::InstantiateType, recipient::Recipient},
-    error::ContractError,
-};
+use common::{ado_base::recipient::Recipient, error::ContractError};
 use cosmwasm_std::{
     coins,
     testing::{mock_env, mock_info},

--- a/contracts/andromeda_timelock/src/contract.rs
+++ b/contracts/andromeda_timelock/src/contract.rs
@@ -46,7 +46,6 @@ pub fn instantiate(
     let res = ADOContract::default().instantiate(
         deps.storage,
         deps.api,
-        &deps.querier,
         info,
         BaseInstantiateMsg {
             ado_type: "timelock".to_string(),

--- a/contracts/andromeda_wrapped_cw721/src/contract.rs
+++ b/contracts/andromeda_wrapped_cw721/src/contract.rs
@@ -34,7 +34,6 @@ pub fn instantiate(
     let resp = contract.instantiate(
         deps.storage,
         deps.api,
-        &deps.querier,
         info,
         BaseInstantiateMsg {
             ado_type: "wrapped_cw721".to_string(),

--- a/packages/ado_base/src/execute.rs
+++ b/packages/ado_base/src/execute.rs
@@ -4,9 +4,7 @@ use common::{
     error::ContractError,
     parse_message, require,
 };
-use cosmwasm_std::{
-    attr, Api, DepsMut, Env, MessageInfo, Order, QuerierWrapper, Response, Storage,
-};
+use cosmwasm_std::{attr, Api, DepsMut, Env, MessageInfo, Order, Response, Storage};
 use serde::de::DeserializeOwned;
 
 type ExecuteFunction<E> = fn(DepsMut, Env, MessageInfo, E) -> Result<Response, ContractError>;
@@ -16,7 +14,6 @@ impl<'a> ADOContract<'a> {
         &self,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &QuerierWrapper,
         info: MessageInfo,
         msg: InstantiateMsg,
     ) -> Result<Response, ContractError> {
@@ -34,7 +31,7 @@ impl<'a> ADOContract<'a> {
         #[cfg(feature = "modules")]
         if let Some(modules) = msg.modules {
             return Ok(self
-                .register_modules(info.sender.as_str(), querier, storage, api, modules)?
+                .register_modules(info.sender.as_str(), storage, modules)?
                 .add_attributes(attributes));
         }
         Ok(Response::new().add_attributes(attributes))
@@ -74,9 +71,7 @@ impl<'a> ADOContract<'a> {
             AndromedaMsg::RegisterModule { module } => {
                 #[cfg(feature = "modules")]
                 return self.execute_register_module(
-                    &deps.querier,
                     deps.storage,
-                    deps.api,
                     info.sender.as_str(),
                     module,
                     true,

--- a/packages/ado_base/src/instantiate.rs
+++ b/packages/ado_base/src/instantiate.rs
@@ -1,37 +1,11 @@
 use crate::ADOContract;
 
 use common::{
-    ado_base::{
-        modules::{InstantiateType, Module},
-        query_get,
-    },
-    encode_binary,
-    error::ContractError,
-    primitive::AndromedaContract,
+    ado_base::query_get, encode_binary, error::ContractError, primitive::AndromedaContract,
 };
 use cosmwasm_std::{Binary, CosmosMsg, QuerierWrapper, ReplyOn, Storage, SubMsg, WasmMsg};
 
 impl<'a> ADOContract<'a> {
-    pub fn generate_instantiate_msg_for_module(
-        &self,
-        storage: &dyn Storage,
-        querier: &QuerierWrapper,
-        module: Module,
-        module_id: u64,
-    ) -> Result<Option<SubMsg>, ContractError> {
-        Ok(if let InstantiateType::New(msg) = module.instantiate {
-            Some(self.generate_instantiate_msg(
-                storage,
-                querier,
-                module_id,
-                msg,
-                module.module_type,
-            )?)
-        } else {
-            None
-        })
-    }
-
     pub fn generate_instantiate_msg(
         &self,
         storage: &dyn Storage,

--- a/packages/ado_base/src/mock_querier.rs
+++ b/packages/ado_base/src/mock_querier.rs
@@ -1,3 +1,4 @@
+use common::ado_base::{AndromedaQuery, QueryMsg};
 use cosmwasm_std::{
     from_binary, from_slice,
     testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR},
@@ -8,6 +9,7 @@ use cw20::{BalanceResponse, Cw20QueryMsg};
 use terra_cosmwasm::TerraQueryWrapper;
 
 pub const MOCK_CW20_CONTRACT: &str = "cw20_contract";
+pub const MOCK_MISSION_CONTRACT: &str = "mission_contract";
 
 pub struct WasmMockQuerier {
     pub base: MockQuerier<TerraQueryWrapper>,
@@ -48,6 +50,7 @@ impl WasmMockQuerier {
             QueryRequest::Wasm(WasmQuery::Smart { contract_addr, msg }) => {
                 match contract_addr.as_str() {
                     MOCK_CW20_CONTRACT => self.handle_cw20_query(msg),
+                    MOCK_MISSION_CONTRACT => self.handle_mission_query(msg),
                     _ => panic!("Unsupported query for contract: {}", contract_addr),
                 }
             }
@@ -64,6 +67,15 @@ impl WasmMockQuerier {
                 SystemResult::Ok(ContractResult::Ok(to_binary(&balance_response).unwrap()))
             }
             _ => panic!("Unsupported Query"),
+        }
+    }
+
+    fn handle_mission_query(&self, msg: &Binary) -> QuerierResult {
+        match from_binary(msg).unwrap() {
+            QueryMsg::AndrQuery(AndromedaQuery::Get(_)) => {
+                SystemResult::Ok(ContractResult::Ok(to_binary(&"actual_address").unwrap()))
+            }
+            _ => SystemResult::Ok(ContractResult::Err("Error".to_string())),
         }
     }
 

--- a/packages/ado_base/src/modules/mod.rs
+++ b/packages/ado_base/src/modules/mod.rs
@@ -1,17 +1,10 @@
 use std::convert::TryInto;
 
 use crate::state::ADOContract;
-use cosmwasm_std::{
-    Api, DepsMut, MessageInfo, Order, QuerierWrapper, Reply, Response, StdError, Storage, Uint64,
-};
+use cosmwasm_std::{Api, DepsMut, MessageInfo, Order, QuerierWrapper, Response, Storage, Uint64};
 use cw_storage_plus::Bound;
 
-use common::{
-    ado_base::modules::{InstantiateType, Module, ModuleInfoWithAddress},
-    error::ContractError,
-    require,
-    response::get_reply_address,
-};
+use common::{ado_base::modules::Module, error::ContractError, require};
 
 pub mod hooks;
 
@@ -19,16 +12,13 @@ impl<'a> ADOContract<'a> {
     pub fn register_modules(
         &self,
         sender: &str,
-        querier: &QuerierWrapper,
         storage: &mut dyn Storage,
-        api: &dyn Api,
         modules: Vec<Module>,
     ) -> Result<Response, ContractError> {
         self.validate_modules(&modules, &self.ado_type.load(storage)?)?;
         let mut resp = Response::new();
         for module in modules {
-            let register_response =
-                self.execute_register_module(querier, storage, api, sender, module, false)?;
+            let register_response = self.execute_register_module(storage, sender, module, false)?;
             resp = resp
                 .add_attributes(register_response.attributes)
                 .add_submessages(register_response.messages)
@@ -41,9 +31,7 @@ impl<'a> ADOContract<'a> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn execute_register_module(
         &self,
-        querier: &QuerierWrapper,
         storage: &mut dyn Storage,
-        api: &dyn Api,
         sender: &str,
         module: Module,
         should_validate: bool,
@@ -52,13 +40,8 @@ impl<'a> ADOContract<'a> {
             self.is_owner_or_operator(storage, sender)?,
             ContractError::Unauthorized {},
         )?;
-        let mut resp = Response::default();
-        let idx = self.register_module(storage, api, &module)?;
-        if let Some(inst_msg) =
-            self.generate_instantiate_msg_for_module(storage, querier, module, idx)?
-        {
-            resp = resp.add_submessage(inst_msg);
-        }
+        let resp = Response::default();
+        self.register_module(storage, &module)?;
         if should_validate {
             self.validate_modules(&self.load_modules(storage)?, &self.ado_type.load(storage)?)?;
         }
@@ -78,21 +61,12 @@ impl<'a> ADOContract<'a> {
             self.is_owner_or_operator(deps.storage, addr)?,
             ContractError::Unauthorized {},
         )?;
-        let mut resp = Response::default();
-        self.alter_module(deps.storage, deps.api, module_idx, &module)?;
-        if let Some(inst_msg) = self.generate_instantiate_msg_for_module(
-            deps.storage,
-            &deps.querier,
-            module,
-            module_idx.u64(),
-        )? {
-            resp = resp.add_submessage(inst_msg);
-        }
+        self.alter_module(deps.storage, module_idx, &module)?;
         self.validate_modules(
             &self.load_modules(deps.storage)?,
             &self.ado_type.load(deps.storage)?,
         )?;
-        Ok(resp
+        Ok(Response::default()
             .add_attribute("action", "alter_module")
             .add_attribute("module_idx", module_idx))
     }
@@ -122,17 +96,12 @@ impl<'a> ADOContract<'a> {
     fn register_module(
         &self,
         storage: &mut dyn Storage,
-        api: &dyn Api,
         module: &Module,
     ) -> Result<u64, ContractError> {
         let idx = self.module_idx.may_load(storage)?.unwrap_or(1);
         let idx_str = idx.to_string();
         self.module_info.save(storage, &idx_str, module)?;
         self.module_idx.save(storage, &(idx + 1))?;
-        if let InstantiateType::Address(addr) = &module.instantiate {
-            self.module_addr
-                .save(storage, &idx_str, &api.addr_validate(addr)?)?;
-        }
 
         Ok(idx)
     }
@@ -146,7 +115,6 @@ impl<'a> ADOContract<'a> {
         let idx_str = idx.to_string();
         self.check_module_mutability(storage, &idx_str)?;
         self.module_info.remove(storage, &idx_str);
-        self.module_addr.remove(storage, &idx_str);
 
         Ok(())
     }
@@ -158,17 +126,12 @@ impl<'a> ADOContract<'a> {
     fn alter_module(
         &self,
         storage: &mut dyn Storage,
-        api: &dyn Api,
         idx: Uint64,
         module: &Module,
     ) -> Result<(), ContractError> {
         let idx_str = idx.to_string();
         self.check_module_mutability(storage, &idx_str)?;
         self.module_info.save(storage, &idx_str, module)?;
-        if let InstantiateType::Address(addr) = &module.instantiate {
-            self.module_addr
-                .save(storage, &idx_str, &api.addr_validate(addr)?)?;
-        }
         Ok(())
     }
 
@@ -206,22 +169,28 @@ impl<'a> ADOContract<'a> {
     }
 
     /// Loads all registered module addresses in Vector form
-    fn load_module_addresses(&self, storage: &dyn Storage) -> Result<Vec<String>, ContractError> {
-        let module_idx = self.module_idx.may_load(storage)?.unwrap_or(1);
-        let min = Some(Bound::Inclusive(1u64.to_le_bytes().to_vec()));
-        // let max = Some(Bound::Inclusive(1u64.to_le_bytes().to_vec()));
-        let module_addresses: Vec<String> = self
-            .module_addr
-            .range(storage, min, None, Order::Ascending)
-            .take(module_idx.try_into().unwrap())
-            .flatten()
-            .map(|(_vec, addr)| addr.to_string())
+    fn load_module_addresses(
+        &self,
+        storage: &dyn Storage,
+        api: &dyn Api,
+        querier: &QuerierWrapper,
+    ) -> Result<Vec<String>, ContractError> {
+        let mission_contract = self.get_mission_contract(storage)?;
+        let module_addresses: Result<Vec<String>, _> = self
+            .load_modules(storage)?
+            .iter()
+            .map(|m| {
+                m.address
+                    .get_address(api, querier, mission_contract.clone())
+            })
             .collect();
 
-        Ok(module_addresses)
+        module_addresses
     }
 
-    /// Loads all modules with their registered addresses in Vector form
+    /*
+     * TODO: Remove when happy with InstantiateType removal.
+     * /// Loads all modules with their registered addresses in Vector form
     fn load_modules_with_address(
         &self,
         storage: &dyn Storage,
@@ -250,7 +219,7 @@ impl<'a> ADOContract<'a> {
         }
 
         Ok(modules_with_addresses)
-    }
+    }*/
 
     /// Validates all modules.
     pub fn validate_modules(
@@ -265,7 +234,9 @@ impl<'a> ADOContract<'a> {
         Ok(())
     }
 
-    pub fn handle_module_reply(
+    /*
+     * TODO: Remove when happyw with InstantiateType removal
+     * pub fn handle_module_reply(
         &self,
         deps: DepsMut,
         msg: Reply,
@@ -287,13 +258,16 @@ impl<'a> ADOContract<'a> {
             .save(deps.storage, &id, &deps.api.addr_validate(&addr)?)?;
 
         Ok(Response::default())
-    }
+    }*/
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use common::ado_base::modules::{ADDRESS_LIST, AUCTION, RECEIPT};
+    use common::{
+        ado_base::modules::{ADDRESS_LIST, AUCTION, RECEIPT},
+        mission::AndrAddress,
+    };
     use cosmwasm_std::{
         testing::{mock_dependencies, mock_info},
         Addr,
@@ -305,7 +279,9 @@ mod tests {
 
         let module = Module {
             module_type: ADDRESS_LIST.to_owned(),
-            instantiate: InstantiateType::Address("address".to_string()),
+            address: AndrAddress {
+                identifier: "address".to_string(),
+            },
             is_mutable: false,
         };
         let deps_mut = deps.as_mut();
@@ -319,9 +295,7 @@ mod tests {
             .unwrap();
 
         let res = ADOContract::default().execute_register_module(
-            &deps_mut.querier,
             deps_mut.storage,
-            deps_mut.api,
             "sender",
             module,
             true,
@@ -336,7 +310,9 @@ mod tests {
 
         let module = Module {
             module_type: ADDRESS_LIST.to_owned(),
-            instantiate: InstantiateType::Address("address".to_string()),
+            address: AndrAddress {
+                identifier: "address".to_string(),
+            },
             is_mutable: false,
         };
         let deps_mut = deps.as_mut();
@@ -351,14 +327,7 @@ mod tests {
             .unwrap();
 
         let res = ADOContract::default()
-            .execute_register_module(
-                &deps_mut.querier,
-                deps_mut.storage,
-                deps_mut.api,
-                "owner",
-                module.clone(),
-                true,
-            )
+            .execute_register_module(deps_mut.storage, "owner", module.clone(), true)
             .unwrap();
 
         assert_eq!(
@@ -373,14 +342,6 @@ mod tests {
                 .load(deps.as_mut().storage, "1")
                 .unwrap()
         );
-
-        assert_eq!(
-            "address".to_string(),
-            ADOContract::default()
-                .module_addr
-                .load(deps.as_mut().storage, "1")
-                .unwrap()
-        );
     }
 
     #[test]
@@ -389,7 +350,9 @@ mod tests {
 
         let module = Module {
             module_type: AUCTION.to_owned(),
-            instantiate: InstantiateType::Address("address".to_string()),
+            address: AndrAddress {
+                identifier: "address".to_string(),
+            },
             is_mutable: false,
         };
         let deps_mut = deps.as_mut();
@@ -404,9 +367,7 @@ mod tests {
             .unwrap();
 
         let res = ADOContract::default().execute_register_module(
-            &deps_mut.querier,
             deps_mut.storage,
-            deps_mut.api,
             "owner",
             module.clone(),
             true,
@@ -420,14 +381,7 @@ mod tests {
         );
 
         let res = ADOContract::default()
-            .execute_register_module(
-                &deps_mut.querier,
-                deps_mut.storage,
-                deps_mut.api,
-                "owner",
-                module,
-                false,
-            )
+            .execute_register_module(deps_mut.storage, "owner", module, false)
             .unwrap();
 
         assert_eq!(
@@ -442,7 +396,9 @@ mod tests {
         let info = mock_info("sender", &[]);
         let module = Module {
             module_type: ADDRESS_LIST.to_owned(),
-            instantiate: InstantiateType::Address("address".to_string()),
+            address: AndrAddress {
+                identifier: "address".to_string(),
+            },
             is_mutable: true,
         };
         ADOContract::default()
@@ -467,7 +423,9 @@ mod tests {
         let info = mock_info("owner", &[]);
         let module = Module {
             module_type: ADDRESS_LIST.to_owned(),
-            instantiate: InstantiateType::Address("address".to_string()),
+            address: AndrAddress {
+                identifier: "address".to_string(),
+            },
             is_mutable: true,
         };
 
@@ -481,17 +439,15 @@ mod tests {
             .save(deps.as_mut().storage, "1", &module)
             .unwrap();
         ADOContract::default()
-            .module_addr
-            .save(deps.as_mut().storage, "1", &Addr::unchecked("address"))
-            .unwrap();
-        ADOContract::default()
             .ado_type
             .save(deps.as_mut().storage, &"cw20".to_string())
             .unwrap();
 
         let module = Module {
             module_type: RECEIPT.to_owned(),
-            instantiate: InstantiateType::Address("other_address".to_string()),
+            address: AndrAddress {
+                identifier: "other_address".to_string(),
+            },
             is_mutable: true,
         };
 
@@ -513,14 +469,6 @@ mod tests {
                 .load(deps.as_mut().storage, "1")
                 .unwrap()
         );
-
-        assert_eq!(
-            "other_address".to_string(),
-            ADOContract::default()
-                .module_addr
-                .load(deps.as_mut().storage, "1")
-                .unwrap()
-        );
     }
 
     #[test]
@@ -529,7 +477,9 @@ mod tests {
         let info = mock_info("owner", &[]);
         let module = Module {
             module_type: ADDRESS_LIST.to_owned(),
-            instantiate: InstantiateType::Address("address".to_string()),
+            address: AndrAddress {
+                identifier: "address".to_string(),
+            },
             is_mutable: false,
         };
 
@@ -543,17 +493,15 @@ mod tests {
             .save(deps.as_mut().storage, "1", &module)
             .unwrap();
         ADOContract::default()
-            .module_addr
-            .save(deps.as_mut().storage, "1", &Addr::unchecked("address"))
-            .unwrap();
-        ADOContract::default()
             .ado_type
             .save(deps.as_mut().storage, &"cw20".to_string())
             .unwrap();
 
         let module = Module {
             module_type: RECEIPT.to_owned(),
-            instantiate: InstantiateType::Address("other_address".to_string()),
+            address: AndrAddress {
+                identifier: "other_address".to_string(),
+            },
             is_mutable: true,
         };
 
@@ -569,7 +517,9 @@ mod tests {
         let info = mock_info("owner", &[]);
         let module = Module {
             module_type: AUCTION.to_owned(),
-            instantiate: InstantiateType::Address("address".to_string()),
+            address: AndrAddress {
+                identifier: "address".to_string(),
+            },
             is_mutable: true,
         };
 
@@ -594,7 +544,9 @@ mod tests {
         let info = mock_info("owner", &[]);
         let module = Module {
             module_type: AUCTION.to_owned(),
-            instantiate: InstantiateType::Address("address".to_string()),
+            address: AndrAddress {
+                identifier: "address".to_string(),
+            },
             is_mutable: true,
         };
 
@@ -606,10 +558,6 @@ mod tests {
         ADOContract::default()
             .module_info
             .save(deps.as_mut().storage, "1", &module)
-            .unwrap();
-        ADOContract::default()
-            .module_addr
-            .save(deps.as_mut().storage, "1", &Addr::unchecked("address"))
             .unwrap();
         ADOContract::default()
             .ado_type
@@ -653,18 +601,15 @@ mod tests {
 
         let module = Module {
             module_type: ADDRESS_LIST.to_owned(),
-            instantiate: InstantiateType::Address("address".to_string()),
+            address: AndrAddress {
+                identifier: "address".to_string(),
+            },
             is_mutable: true,
         };
 
         ADOContract::default()
             .module_info
             .save(deps.as_mut().storage, "1", &module)
-            .unwrap();
-
-        ADOContract::default()
-            .module_addr
-            .save(deps.as_mut().storage, "1", &Addr::unchecked("address"))
             .unwrap();
 
         let res = ADOContract::default()
@@ -678,9 +623,6 @@ mod tests {
             res
         );
 
-        assert!(!ADOContract::default()
-            .module_addr
-            .has(deps.as_mut().storage, "1"));
         assert!(!ADOContract::default()
             .module_info
             .has(deps.as_mut().storage, "1"));
@@ -697,18 +639,15 @@ mod tests {
 
         let module = Module {
             module_type: ADDRESS_LIST.to_owned(),
-            instantiate: InstantiateType::Address("address".to_string()),
+            address: AndrAddress {
+                identifier: "address".to_string(),
+            },
             is_mutable: false,
         };
 
         ADOContract::default()
             .module_info
             .save(deps.as_mut().storage, "1", &module)
-            .unwrap();
-
-        ADOContract::default()
-            .module_addr
-            .save(deps.as_mut().storage, "1", &Addr::unchecked("address"))
             .unwrap();
 
         let res =

--- a/packages/ado_base/src/state.rs
+++ b/packages/ado_base/src/state.rs
@@ -17,8 +17,6 @@ pub struct ADOContract<'a> {
     #[cfg(feature = "modules")]
     pub module_info: Map<'a, &'a str, Module>,
     #[cfg(feature = "modules")]
-    pub module_addr: Map<'a, &'a str, Addr>,
-    #[cfg(feature = "modules")]
     pub module_idx: Item<'a, u64>,
     #[cfg(feature = "withdraw")]
     pub withdrawable_tokens: Map<'a, &'a str, AssetInfo>,
@@ -35,8 +33,6 @@ impl<'a> Default for ADOContract<'a> {
             primitive_contract: Item::new("primitive_contract"),
             #[cfg(feature = "modules")]
             module_info: Map::new("andr_modules"),
-            #[cfg(feature = "modules")]
-            module_addr: Map::new("andr_module_addresses"),
             #[cfg(feature = "modules")]
             module_idx: Item::new("andr_module_idx"),
             #[cfg(feature = "withdraw")]

--- a/packages/andromeda_protocol/src/swapper.rs
+++ b/packages/andromeda_protocol/src/swapper.rs
@@ -1,13 +1,18 @@
 use astroport::asset::AssetInfo as AstroportAssetInfo;
-use common::ado_base::{
-    modules::InstantiateType, recipient::Recipient, AndromedaMsg, AndromedaQuery,
-};
+use common::ado_base::{recipient::Recipient, AndromedaMsg, AndromedaQuery};
 // To be used in the swapper contract.
 pub use astroport::querier::{query_balance, query_token_balance};
-use cosmwasm_std::Addr;
+use cosmwasm_std::{Addr, Binary};
 use cw20::Cw20ReceiveMsg;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum InstantiateType {
+    New(Binary),
+    Address(String),
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/packages/common/src/ado_base/modules.rs
+++ b/packages/common/src/ado_base/modules.rs
@@ -1,5 +1,4 @@
-use crate::{error::ContractError, require};
-use cosmwasm_std::Binary;
+use crate::{error::ContractError, mission::AndrAddress, require};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -10,32 +9,33 @@ pub const AUCTION: &str = "auction";
 pub const RECEIPT: &str = "receipt";
 pub const OTHER: &str = "other";
 
+// TODO: Remove InstantiateType when we are confident with the AndrAddress replacement.
 /// Modules can be instantiated in two different ways
 /// New - Provide an instantiation message for the contract, a new contract will be instantiated and the address recorded
 /// Address - Provide an address for an already instantiated module contract
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+/*#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum InstantiateType {
     New(Binary),
     Address(String),
-}
+}*/
 
 /// A struct describing a token module, provided with the instantiation message this struct is used to record the info about the module and how/if it should be instantiated
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct Module {
     pub module_type: String,
-    pub instantiate: InstantiateType,
+    pub address: AndrAddress,
     pub is_mutable: bool,
 }
 
-/// Struct used to represent a module and its currently recorded address
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+// TODO: Remove ModuleInfoWithAddress when we are confident with the AndrAddress replacement.
+/*#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct ModuleInfoWithAddress {
     pub module: Module,
     pub address: String,
-}
+}*/
 
 impl Module {
     /// Validates `self` by checking that it is unique, does not conflict with any other module,
@@ -83,7 +83,9 @@ mod tests {
     fn test_validate_addresslist() {
         let addresslist_module = Module {
             module_type: ADDRESS_LIST.to_owned(),
-            instantiate: InstantiateType::Address("".to_string()),
+            address: AndrAddress {
+                identifier: "".to_string(),
+            },
             is_mutable: false,
         };
 
@@ -95,7 +97,9 @@ mod tests {
 
         let auction_module = Module {
             module_type: AUCTION.to_owned(),
-            instantiate: InstantiateType::Address("".into()),
+            address: AndrAddress {
+                identifier: "".to_string(),
+            },
             is_mutable: false,
         };
         addresslist_module
@@ -107,7 +111,9 @@ mod tests {
     fn test_validate_auction() {
         let module = Module {
             module_type: AUCTION.to_owned(),
-            instantiate: InstantiateType::Address("".to_string()),
+            address: AndrAddress {
+                identifier: "".to_string(),
+            },
             is_mutable: false,
         };
 
@@ -124,7 +130,9 @@ mod tests {
 
         let other_module = Module {
             module_type: RATES.to_owned(),
-            instantiate: InstantiateType::Address("".to_string()),
+            address: AndrAddress {
+                identifier: "".to_string(),
+            },
             is_mutable: false,
         };
         module
@@ -136,7 +144,9 @@ mod tests {
     fn test_validate_rates() {
         let module = Module {
             module_type: RATES.to_owned(),
-            instantiate: InstantiateType::Address("".to_string()),
+            address: AndrAddress {
+                identifier: "".to_string(),
+            },
             is_mutable: false,
         };
 
@@ -145,7 +155,9 @@ mod tests {
 
         let other_module = Module {
             module_type: ADDRESS_LIST.to_owned(),
-            instantiate: InstantiateType::Address("".to_string()),
+            address: AndrAddress {
+                identifier: "".to_string(),
+            },
             is_mutable: false,
         };
         module
@@ -157,7 +169,9 @@ mod tests {
     fn test_validate_receipt() {
         let module = Module {
             module_type: RECEIPT.to_owned(),
-            instantiate: InstantiateType::Address("".to_string()),
+            address: AndrAddress {
+                identifier: "".to_string(),
+            },
             is_mutable: false,
         };
 
@@ -166,7 +180,9 @@ mod tests {
 
         let other_module = Module {
             module_type: ADDRESS_LIST.to_owned(),
-            instantiate: InstantiateType::Address("".to_string()),
+            address: AndrAddress {
+                identifier: "".to_string(),
+            },
             is_mutable: false,
         };
         module
@@ -178,13 +194,17 @@ mod tests {
     fn test_validate_uniqueness() {
         let module1 = Module {
             module_type: RECEIPT.to_owned(),
-            instantiate: InstantiateType::Address("addr1".to_string()),
+            address: AndrAddress {
+                identifier: "addr1".to_string(),
+            },
             is_mutable: false,
         };
 
         let module2 = Module {
             module_type: RECEIPT.to_owned(),
-            instantiate: InstantiateType::Address("addr2".to_string()),
+            address: AndrAddress {
+                identifier: "addr2".to_string(),
+            },
             is_mutable: false,
         };
 


### PR DESCRIPTION
# Motivation
Now that we have a mission contract, we can use its namespacing feature to simplify module assignment. Now in order to assign modules to an ADO, the modules need to be instantiated by the mission. 

# Implementation
As per request I commented out most of the old logic in case this new approach is not sufficient for any reason. Using the mission for instantiation simplifies the code a lot, and while I haven't tested it yet, it should also reduce the contract sizes. 

I kept the use of `InstantiateType` in Swapper for now, as we might want to keep allowing it to instantiate the swapper_impl, but that could be subject to change. 

# Testing

## Unit/Integration tests
I updated existing tests to use `AndrAddress` and added a unit test for `load_module_addresses` as that now uses the `AndrAddress` now. There are more tests to add, but those will be tackled in a PR centred around improving test coverage of ado_base.

## On-chain tests
No since mission is not ready for testing yet. 

# Future work
Removing the commented out code once we are confident in this change. 