### PR TITLE
CU-24hkbk8 | Move references to Anchor external addresses to primitive contract

### DIFF
--- a/contracts/andromeda_anchor/Cargo.toml
+++ b/contracts/andromeda_anchor/Cargo.toml
@@ -32,7 +32,7 @@ cosmwasm-bignumber = "2.2.0"
 
 andromeda-protocol = { version = "0.1.0", path = "../../packages/andromeda_protocol" }
 common = { version = "0.1.0", path = "../../packages/common" }
-ado-base = { path = "../../packages/ado_base", version = "0.1.0"}
+ado-base = { path = "../../packages/ado_base", version = "0.1.0", "features" = ["primitive"] }
 
 [dev-dependencies]
 terra-cosmwasm = { version = "2.2.0" }

--- a/contracts/andromeda_anchor/src/lib.rs
+++ b/contracts/andromeda_anchor/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod contract;
+mod primitive_keys;
 pub mod querier;
 pub mod state;
 #[cfg(test)]

--- a/contracts/andromeda_anchor/src/primitive_keys.rs
+++ b/contracts/andromeda_anchor/src/primitive_keys.rs
@@ -1,0 +1,17 @@
+pub const ANCHOR_MARKET: &str = "anchor_market_contract";
+pub const ANCHOR_OVERSEER: &str = "anchor_overseer_contract";
+pub const ANCHOR_BLUNA_HUB: &str = "anchor_bluna_hub_contract";
+pub const ANCHOR_BLUNA_CUSTODY: &str = "anchor_bluna_custody_contract";
+pub const ANCHOR_ORACLE: &str = "anchor_oracle_contract";
+pub const ANCHOR_AUST: &str = "anchor_aust_contract";
+pub const ANCHOR_BLUNA: &str = "anchor_bluna_contract";
+
+pub const ADDRESSES_TO_CACHE: [&str; 7] = [
+    ANCHOR_MARKET,
+    ANCHOR_OVERSEER,
+    ANCHOR_BLUNA_HUB,
+    ANCHOR_BLUNA_CUSTODY,
+    ANCHOR_ORACLE,
+    ANCHOR_AUST,
+    ANCHOR_BLUNA,
+];

--- a/contracts/andromeda_anchor/src/querier.rs
+++ b/contracts/andromeda_anchor/src/querier.rs
@@ -1,24 +1,9 @@
 use common::{encode_binary, error::ContractError};
 use cosmwasm_std::{QuerierWrapper, QueryRequest, WasmQuery};
 use moneymarket::{
-    custody::{ConfigResponse as CustodyConfigResponse, QueryMsg as CustodyQueryMsg},
-    market::{
-        BorrowerInfoResponse, ConfigResponse as MarketConfigResponse, QueryMsg as MarketQueryMsg,
-    },
-    overseer::{
-        CollateralsResponse, ConfigResponse as OverseerConfigResponse, QueryMsg as OverseerQueryMsg,
-    },
+    market::{BorrowerInfoResponse, QueryMsg as MarketQueryMsg},
+    overseer::{CollateralsResponse, QueryMsg as OverseerQueryMsg},
 };
-
-pub fn query_market_config(
-    querier: &QuerierWrapper,
-    anchor_market: String,
-) -> Result<MarketConfigResponse, ContractError> {
-    Ok(querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
-        contract_addr: anchor_market,
-        msg: encode_binary(&MarketQueryMsg::Config {})?,
-    }))?)
-}
 
 pub fn query_borrower_info(
     querier: &QuerierWrapper,
@@ -31,26 +16,6 @@ pub fn query_borrower_info(
             borrower,
             block_height: None,
         })?,
-    }))?)
-}
-
-pub fn query_custody_config(
-    querier: &QuerierWrapper,
-    anchor_custody: String,
-) -> Result<CustodyConfigResponse, ContractError> {
-    Ok(querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
-        contract_addr: anchor_custody,
-        msg: encode_binary(&CustodyQueryMsg::Config {})?,
-    }))?)
-}
-
-pub fn query_overseer_config(
-    querier: &QuerierWrapper,
-    anchor_overseer: String,
-) -> Result<OverseerConfigResponse, ContractError> {
-    Ok(querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
-        contract_addr: anchor_overseer,
-        msg: encode_binary(&OverseerQueryMsg::Config {})?,
     }))?)
 }
 

--- a/contracts/andromeda_anchor/src/state.rs
+++ b/contracts/andromeda_anchor/src/state.rs
@@ -1,25 +1,13 @@
 use common::ado_base::recipient::Recipient;
-use cosmwasm_std::{Addr, Uint128};
+use cosmwasm_std::Uint128;
 use cw_storage_plus::{Item, Map};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-pub const CONFIG: Item<Config> = Item::new("config");
 pub const POSITION: Map<&str, Position> = Map::new("position");
 pub const PREV_AUST_BALANCE: Item<Uint128> = Item::new("prev_aust_balance");
 pub const PREV_UUSD_BALANCE: Item<Uint128> = Item::new("prev_uusd_balance");
 pub const RECIPIENT_ADDR: Item<String> = Item::new("recipient_addr");
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct Config {
-    pub anchor_market: Addr,
-    pub aust_token: Addr,
-    pub anchor_bluna_hub: Addr,
-    pub anchor_bluna_custody: Addr,
-    pub anchor_overseer: Addr,
-    pub bluna_token: Addr,
-    pub anchor_oracle: Addr,
-}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Position {

--- a/contracts/andromeda_anchor/src/testing/mock_querier.rs
+++ b/contracts/andromeda_anchor/src/testing/mock_querier.rs
@@ -4,16 +4,21 @@ use cosmwasm_std::{
     from_binary, from_slice, to_binary, Binary, Coin, ContractResult, OwnedDeps, Querier,
     QuerierResult, QueryRequest, SystemError, SystemResult, Uint128, WasmQuery,
 };
+
+use crate::primitive_keys::{
+    ANCHOR_AUST, ANCHOR_BLUNA, ANCHOR_BLUNA_CUSTODY, ANCHOR_BLUNA_HUB, ANCHOR_MARKET,
+    ANCHOR_ORACLE, ANCHOR_OVERSEER,
+};
+use andromeda_protocol::primitive::QueryMsg as PrimitiveQueryMsg;
+use common::{
+    ado_base::AndromedaQuery,
+    primitive::{GetValueResponse, Primitive},
+};
 use cw20::{BalanceResponse, Cw20QueryMsg};
 use moneymarket::{
-    custody::{BAssetInfo, ConfigResponse as CustodyConfigResponse, QueryMsg as CustodyQueryMsg},
-    market::{
-        BorrowerInfoResponse, ConfigResponse as MarketConfigResponse, QueryMsg as MarketQueryMsg,
-    },
+    market::{BorrowerInfoResponse, QueryMsg as MarketQueryMsg},
     oracle::{PriceResponse, QueryMsg as OracleQueryMsg},
-    overseer::{
-        CollateralsResponse, ConfigResponse as OverseerConfigResponse, QueryMsg as OverseerQueryMsg,
-    },
+    overseer::{CollateralsResponse, QueryMsg as OverseerQueryMsg},
 };
 use terra_cosmwasm::TerraQueryWrapper;
 
@@ -24,6 +29,8 @@ pub const MOCK_AUST_TOKEN: &str = "aust_token";
 pub const MOCK_BLUNA_TOKEN: &str = "bluna_token";
 pub const MOCK_BLUNA_HUB_CONTRACT: &str = "bluna_hub_contract";
 pub const MOCK_ORACLE_CONTRACT: &str = "anchor_oracle";
+
+pub const MOCK_PRIMITIVE_CONTRACT: &str = "primitive_contract";
 
 pub struct WasmMockQuerier {
     pub base: MockQuerier<TerraQueryWrapper>,
@@ -65,11 +72,11 @@ impl WasmMockQuerier {
             QueryRequest::Wasm(WasmQuery::Smart { contract_addr, msg }) => {
                 match contract_addr.as_str() {
                     MOCK_MARKET_CONTRACT => self.handle_market_query(msg),
-                    MOCK_CUSTODY_CONTRACT => self.handle_custody_query(msg),
                     MOCK_OVERSEER_CONTRACT => self.handle_overseer_query(msg),
                     MOCK_ORACLE_CONTRACT => self.handle_oracle_query(msg),
                     MOCK_AUST_TOKEN => self.handle_aust_query(msg),
                     MOCK_BLUNA_TOKEN => self.handle_bluna_query(msg),
+                    MOCK_PRIMITIVE_CONTRACT => self.handle_primitive_query(msg),
                     _ => panic!("Unsupported Query for address {}", contract_addr),
                 }
             }
@@ -89,44 +96,6 @@ impl WasmMockQuerier {
                 };
                 SystemResult::Ok(ContractResult::Ok(to_binary(&res).unwrap()))
             }
-            MarketQueryMsg::Config {} => {
-                let res = MarketConfigResponse {
-                    owner_addr: "owner".to_string(),
-                    aterra_contract: MOCK_AUST_TOKEN.to_owned(),
-                    interest_model: "interest_model".to_string(),
-                    distribution_model: "distribution_model".to_string(),
-                    overseer_contract: MOCK_OVERSEER_CONTRACT.to_owned(),
-                    collector_contract: "collector_contract".to_string(),
-                    distributor_contract: "distributor_contract".to_string(),
-                    stable_denom: "uusd".to_string(),
-                    max_borrow_factor: Decimal256::one(),
-                };
-
-                SystemResult::Ok(ContractResult::Ok(to_binary(&res).unwrap()))
-            }
-            _ => panic!("Unsupported Query"),
-        }
-    }
-
-    fn handle_custody_query(&self, msg: &Binary) -> QuerierResult {
-        match from_binary(msg).unwrap() {
-            CustodyQueryMsg::Config {} => {
-                let res = CustodyConfigResponse {
-                    owner: "owner".to_string(),
-                    collateral_token: MOCK_BLUNA_TOKEN.to_owned(),
-                    overseer_contract: MOCK_OVERSEER_CONTRACT.to_owned(),
-                    market_contract: MOCK_MARKET_CONTRACT.to_owned(),
-                    reward_contract: "reward_contract".to_string(),
-                    liquidation_contract: "liquidation_contract".to_string(),
-                    stable_denom: "uusd".to_owned(),
-                    basset_info: BAssetInfo {
-                        name: "name".to_string(),
-                        symbol: "symbol".to_string(),
-                        decimals: 6,
-                    },
-                };
-                SystemResult::Ok(ContractResult::Ok(to_binary(&res).unwrap()))
-            }
             _ => panic!("Unsupported Query"),
         }
     }
@@ -137,23 +106,6 @@ impl WasmMockQuerier {
                 let res = CollateralsResponse {
                     borrower,
                     collaterals: vec![(MOCK_BLUNA_TOKEN.to_owned(), Uint256::from(100u128))],
-                };
-                SystemResult::Ok(ContractResult::Ok(to_binary(&res).unwrap()))
-            }
-            OverseerQueryMsg::Config {} => {
-                let res = OverseerConfigResponse {
-                    owner_addr: "owner".to_string(),
-                    oracle_contract: MOCK_ORACLE_CONTRACT.to_owned(),
-                    market_contract: MOCK_MARKET_CONTRACT.to_owned(),
-                    liquidation_contract: "liquidiation_contract".to_string(),
-                    collector_contract: "collector_contract".to_string(),
-                    threshold_deposit_rate: Decimal256::one(),
-                    target_deposit_rate: Decimal256::one(),
-                    buffer_distribution_factor: Decimal256::one(),
-                    anc_purchase_factor: Decimal256::one(),
-                    stable_denom: "uusd".to_string(),
-                    epoch_period: 0,
-                    price_timeframe: 0,
                 };
                 SystemResult::Ok(ContractResult::Ok(to_binary(&res).unwrap()))
             }
@@ -194,6 +146,47 @@ impl WasmMockQuerier {
                     balance: self.token_balance,
                 };
                 SystemResult::Ok(ContractResult::Ok(to_binary(&res).unwrap()))
+            }
+            _ => panic!("Unsupported Query"),
+        }
+    }
+
+    fn handle_primitive_query(&self, msg: &Binary) -> QuerierResult {
+        match from_binary(msg).unwrap() {
+            PrimitiveQueryMsg::AndrQuery(AndromedaQuery::Get(data)) => {
+                let name: String = from_binary(&data.unwrap()).unwrap();
+                let msg_response = match name.as_str() {
+                    ANCHOR_MARKET => GetValueResponse {
+                        name,
+                        value: Primitive::String(MOCK_MARKET_CONTRACT.to_owned()),
+                    },
+                    ANCHOR_OVERSEER => GetValueResponse {
+                        name,
+                        value: Primitive::String(MOCK_OVERSEER_CONTRACT.to_owned()),
+                    },
+                    ANCHOR_BLUNA_HUB => GetValueResponse {
+                        name,
+                        value: Primitive::String(MOCK_BLUNA_HUB_CONTRACT.to_owned()),
+                    },
+                    ANCHOR_BLUNA_CUSTODY => GetValueResponse {
+                        name,
+                        value: Primitive::String(MOCK_CUSTODY_CONTRACT.to_owned()),
+                    },
+                    ANCHOR_ORACLE => GetValueResponse {
+                        name,
+                        value: Primitive::String(MOCK_ORACLE_CONTRACT.to_owned()),
+                    },
+                    ANCHOR_AUST => GetValueResponse {
+                        name,
+                        value: Primitive::String(MOCK_AUST_TOKEN.to_owned()),
+                    },
+                    ANCHOR_BLUNA => GetValueResponse {
+                        name,
+                        value: Primitive::String(MOCK_BLUNA_TOKEN.to_owned()),
+                    },
+                    _ => panic!("Unsupported primitive name"),
+                };
+                SystemResult::Ok(ContractResult::Ok(to_binary(&msg_response).unwrap()))
             }
             _ => panic!("Unsupported Query"),
         }

--- a/contracts/andromeda_anchor/src/testing/tests.rs
+++ b/contracts/andromeda_anchor/src/testing/tests.rs
@@ -1,11 +1,23 @@
-use crate::contract::{execute, instantiate, query, reply, DEPOSIT_ID, WITHDRAW_ID};
-use crate::state::{
-    Config, Position, CONFIG, POSITION, PREV_AUST_BALANCE, PREV_UUSD_BALANCE, RECIPIENT_ADDR,
+use cosmwasm_bignumber::{Decimal256, Uint256};
+use cosmwasm_std::{
+    attr, coin, coins, from_binary,
+    testing::{mock_env, mock_info},
+    to_binary, BankMsg, Coin, ContractResult, CosmosMsg, DepsMut, Reply, Response, SubMsg,
+    SubMsgExecutionResponse, Uint128, WasmMsg,
 };
+
+use crate::contract::{execute, instantiate, query, reply, DEPOSIT_ID, WITHDRAW_ID};
+use crate::primitive_keys::{
+    ANCHOR_AUST, ANCHOR_BLUNA, ANCHOR_BLUNA_CUSTODY, ANCHOR_BLUNA_HUB, ANCHOR_MARKET,
+    ANCHOR_ORACLE, ANCHOR_OVERSEER,
+};
+use crate::state::{Position, POSITION, PREV_AUST_BALANCE, PREV_UUSD_BALANCE, RECIPIENT_ADDR};
 use crate::testing::mock_querier::{
     mock_dependencies_custom, MOCK_AUST_TOKEN, MOCK_BLUNA_HUB_CONTRACT, MOCK_BLUNA_TOKEN,
     MOCK_CUSTODY_CONTRACT, MOCK_MARKET_CONTRACT, MOCK_ORACLE_CONTRACT, MOCK_OVERSEER_CONTRACT,
+    MOCK_PRIMITIVE_CONTRACT,
 };
+use ado_base::ADOContract;
 use andromeda_protocol::anchor::{
     BLunaHubCw20HookMsg, BLunaHubExecuteMsg, Cw20HookMsg, ExecuteMsg, InstantiateMsg,
     PositionResponse, QueryMsg,
@@ -17,13 +29,6 @@ use common::{
     },
     error::ContractError,
     withdraw::{Withdrawal, WithdrawalType},
-};
-use cosmwasm_bignumber::{Decimal256, Uint256};
-use cosmwasm_std::{
-    attr, coin, coins, from_binary,
-    testing::{mock_env, mock_info},
-    to_binary, Addr, BankMsg, Coin, ContractResult, CosmosMsg, DepsMut, Reply, Response, SubMsg,
-    SubMsgExecutionResponse, Uint128, WasmMsg,
 };
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use moneymarket::{
@@ -76,9 +81,7 @@ fn init(deps: DepsMut) {
     let owner = "owner";
     let info = mock_info(owner, &[]);
     let msg = InstantiateMsg {
-        anchor_bluna_hub: MOCK_BLUNA_HUB_CONTRACT.to_owned(),
-        anchor_bluna_custody: MOCK_CUSTODY_CONTRACT.to_owned(),
-        anchor_market: MOCK_MARKET_CONTRACT.to_owned(),
+        primitive_contract: MOCK_PRIMITIVE_CONTRACT.to_owned(),
     };
     let res = instantiate(deps, env, info, msg).unwrap();
 
@@ -89,19 +92,48 @@ fn init(deps: DepsMut) {
 fn test_instantiate() {
     let mut deps = mock_dependencies_custom(&[]);
     init(deps.as_mut());
-    let config = CONFIG.load(deps.as_ref().storage).unwrap();
-
+    let contract = ADOContract::default();
     assert_eq!(
-        Config {
-            anchor_market: Addr::unchecked(MOCK_MARKET_CONTRACT),
-            aust_token: Addr::unchecked(MOCK_AUST_TOKEN),
-            anchor_bluna_hub: Addr::unchecked(MOCK_BLUNA_HUB_CONTRACT),
-            anchor_bluna_custody: Addr::unchecked(MOCK_CUSTODY_CONTRACT),
-            anchor_overseer: Addr::unchecked(MOCK_OVERSEER_CONTRACT),
-            bluna_token: Addr::unchecked(MOCK_BLUNA_TOKEN),
-            anchor_oracle: Addr::unchecked(MOCK_ORACLE_CONTRACT)
-        },
-        config
+        MOCK_MARKET_CONTRACT,
+        contract
+            .get_cached_address(deps.as_ref().storage, ANCHOR_MARKET)
+            .unwrap()
+    );
+    assert_eq!(
+        MOCK_OVERSEER_CONTRACT,
+        contract
+            .get_cached_address(deps.as_ref().storage, ANCHOR_OVERSEER)
+            .unwrap()
+    );
+    assert_eq!(
+        MOCK_BLUNA_HUB_CONTRACT,
+        contract
+            .get_cached_address(deps.as_ref().storage, ANCHOR_BLUNA_HUB)
+            .unwrap()
+    );
+    assert_eq!(
+        MOCK_CUSTODY_CONTRACT,
+        contract
+            .get_cached_address(deps.as_ref().storage, ANCHOR_BLUNA_CUSTODY)
+            .unwrap()
+    );
+    assert_eq!(
+        MOCK_ORACLE_CONTRACT,
+        contract
+            .get_cached_address(deps.as_ref().storage, ANCHOR_ORACLE)
+            .unwrap()
+    );
+    assert_eq!(
+        MOCK_AUST_TOKEN,
+        contract
+            .get_cached_address(deps.as_ref().storage, ANCHOR_AUST)
+            .unwrap()
+    );
+    assert_eq!(
+        MOCK_BLUNA_TOKEN,
+        contract
+            .get_cached_address(deps.as_ref().storage, ANCHOR_BLUNA)
+            .unwrap()
     );
 }
 

--- a/packages/ado_base/src/execute.rs
+++ b/packages/ado_base/src/execute.rs
@@ -15,8 +15,10 @@ impl<'a> ADOContract<'a> {
     pub fn instantiate(
         &self,
         storage: &mut dyn Storage,
-        api: &dyn Api,
-        querier: &QuerierWrapper,
+        #[cfg(any(feature = "modules", feature = "primitive"))] api: &dyn Api,
+        #[cfg(not(any(feature = "modules", feature = "primitive")))] _api: &dyn Api,
+        #[cfg(feature = "modules")] querier: &QuerierWrapper,
+        #[cfg(not(feature = "modules"))] _querier: &QuerierWrapper,
         info: MessageInfo,
         msg: InstantiateMsg,
     ) -> Result<Response, ContractError> {

--- a/packages/ado_base/src/execute.rs
+++ b/packages/ado_base/src/execute.rs
@@ -40,7 +40,7 @@ impl<'a> ADOContract<'a> {
         Ok(Response::new().add_attributes(attributes))
     }
 
-    #[allow(clippy::unreachable)]
+    #[allow(unreachable_patterns)]
     pub fn execute<E: DeserializeOwned>(
         &self,
         deps: DepsMut,

--- a/packages/ado_base/src/execute.rs
+++ b/packages/ado_base/src/execute.rs
@@ -57,6 +57,9 @@ impl<'a> ADOContract<'a> {
             AndromedaMsg::UpdateOperators { operators } => {
                 self.execute_update_operators(deps, info, operators)
             }
+            AndromedaMsg::UpdateMissionContract { address } => {
+                self.execute_update_mission_contract(deps, info, address)
+            }
             #[cfg(feature = "withdraw")]
             AndromedaMsg::Withdraw {
                 recipient,
@@ -73,9 +76,6 @@ impl<'a> ADOContract<'a> {
             #[cfg(feature = "modules")]
             AndromedaMsg::AlterModule { module_idx, module } => {
                 self.execute_alter_module(deps, info, module_idx, module)
-            }
-            AndromedaMsg::UpdateMissionContract { address } => {
-                self.execute_update_mission_contract(deps, info, address)
             }
             #[cfg(feature = "primitive")]
             AndromedaMsg::RefreshAddress { contract } => {

--- a/packages/ado_base/src/instantiate.rs
+++ b/packages/ado_base/src/instantiate.rs
@@ -7,14 +7,13 @@ use common::{
     },
     encode_binary,
     error::ContractError,
-    primitive::AndromedaContract,
 };
 use cosmwasm_std::{Binary, CosmosMsg, QuerierWrapper, ReplyOn, Storage, SubMsg, WasmMsg};
 
 impl<'a> ADOContract<'a> {
     pub fn generate_instantiate_msg_for_module(
         &self,
-        storage: &dyn Storage,
+        storage: &mut dyn Storage,
         querier: &QuerierWrapper,
         module: Module,
         module_id: u64,
@@ -34,7 +33,7 @@ impl<'a> ADOContract<'a> {
 
     pub fn generate_instantiate_msg(
         &self,
-        storage: &dyn Storage,
+        storage: &mut dyn Storage,
         querier: &QuerierWrapper,
         msg_id: u64,
         msg: Binary,
@@ -63,11 +62,12 @@ impl<'a> ADOContract<'a> {
 
     fn get_code_id(
         &self,
-        storage: &dyn Storage,
+        storage: &mut dyn Storage,
         querier: &QuerierWrapper,
         name: &str,
     ) -> Result<u64, ContractError> {
-        let factory_address = self.get_address(storage, querier, AndromedaContract::Factory)?;
+        // Do we want to cache the factory address?
+        let factory_address = self.get_address_from_primitive(storage, querier, "factory")?;
         let code_id: u64 = query_get(Some(encode_binary(&name)?), factory_address, querier)?;
         Ok(code_id)
     }

--- a/packages/ado_base/src/mock_querier.rs
+++ b/packages/ado_base/src/mock_querier.rs
@@ -1,3 +1,7 @@
+use common::{
+    ado_base::{AndromedaQuery, QueryMsg},
+    primitive::{GetValueResponse, Primitive},
+};
 use cosmwasm_std::{
     from_binary, from_slice,
     testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR},
@@ -8,6 +12,7 @@ use cw20::{BalanceResponse, Cw20QueryMsg};
 use terra_cosmwasm::TerraQueryWrapper;
 
 pub const MOCK_CW20_CONTRACT: &str = "cw20_contract";
+pub const MOCK_PRIMITIVE_CONTRACT: &str = "primitive_contract";
 
 pub struct WasmMockQuerier {
     pub base: MockQuerier<TerraQueryWrapper>,
@@ -48,6 +53,7 @@ impl WasmMockQuerier {
             QueryRequest::Wasm(WasmQuery::Smart { contract_addr, msg }) => {
                 match contract_addr.as_str() {
                     MOCK_CW20_CONTRACT => self.handle_cw20_query(msg),
+                    MOCK_PRIMITIVE_CONTRACT => self.handle_primitive_query(msg),
                     _ => panic!("Unsupported query for contract: {}", contract_addr),
                 }
             }
@@ -62,6 +68,27 @@ impl WasmMockQuerier {
                     balance: 10u128.into(),
                 };
                 SystemResult::Ok(ContractResult::Ok(to_binary(&balance_response).unwrap()))
+            }
+            _ => panic!("Unsupported Query"),
+        }
+    }
+
+    fn handle_primitive_query(&self, msg: &Binary) -> QuerierResult {
+        match from_binary(msg).unwrap() {
+            QueryMsg::AndrQuery(AndromedaQuery::Get(data)) => {
+                let name: String = from_binary(&data.unwrap()).unwrap();
+                let msg_response = match name.as_str() {
+                    "key1" => GetValueResponse {
+                        name,
+                        value: Primitive::String("address1".to_string()),
+                    },
+                    "key2" => GetValueResponse {
+                        name,
+                        value: Primitive::String("address2".to_string()),
+                    },
+                    _ => panic!("Unsupported primitive name"),
+                };
+                SystemResult::Ok(ContractResult::Ok(to_binary(&msg_response).unwrap()))
             }
             _ => panic!("Unsupported Query"),
         }

--- a/packages/ado_base/src/primitive.rs
+++ b/packages/ado_base/src/primitive.rs
@@ -3,7 +3,11 @@ use crate::ADOContract;
 use common::{
     ado_base::query_get, encode_binary, error::ContractError, primitive::GetValueResponse,
 };
-use cosmwasm_std::{QuerierWrapper, Storage};
+use cosmwasm_std::{DepsMut, Order, QuerierWrapper, Response, Storage};
+use cw_storage_plus::Bound;
+
+const DEFAULT_LIMIT: u32 = 10;
+const MAX_LIMIT: u32 = 20;
 
 impl<'a> ADOContract<'a> {
     /// Gets the value of `contract` in `self.cached_addresses`.
@@ -28,7 +32,8 @@ impl<'a> ADOContract<'a> {
         Ok(())
     }
 
-    pub(crate) fn get_address_from_primitive(
+    /// Gets the address for `contract` stored in the primitive contract.
+    pub fn get_address_from_primitive(
         &self,
         storage: &dyn Storage,
         querier: &QuerierWrapper,
@@ -40,5 +45,40 @@ impl<'a> ADOContract<'a> {
         let address = res.value.try_get_string()?;
 
         Ok(address)
+    }
+
+    pub(crate) fn execute_refresh_address(
+        &self,
+        deps: DepsMut,
+        contract: String,
+    ) -> Result<Response, ContractError> {
+        self.cache_address(deps.storage, &deps.querier, &contract)?;
+        Ok(Response::new()
+            .add_attribute("action", "refresh_address")
+            .add_attribute("contract", contract))
+    }
+
+    pub(crate) fn execute_refresh_addresses(
+        &self,
+        deps: DepsMut,
+        start_after: Option<String>,
+        limit: Option<u32>,
+    ) -> Result<Response, ContractError> {
+        let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+        let start = start_after.map(Bound::exclusive);
+        let keys: Vec<String> = self
+            .cached_addresses
+            .keys(deps.storage, start, None, Order::Ascending)
+            .take(limit)
+            .map(String::from_utf8)
+            .collect::<Result<Vec<String>, _>>()?;
+
+        for key in keys.iter() {
+            self.cache_address(deps.storage, &deps.querier, &key)?;
+        }
+
+        Ok(Response::new()
+            .add_attribute("action", "refresh_addresses")
+            .add_attribute("last_key", keys.last().unwrap_or(&String::from("None"))))
     }
 }

--- a/packages/ado_base/src/primitive.rs
+++ b/packages/ado_base/src/primitive.rs
@@ -1,23 +1,44 @@
 use crate::ADOContract;
 
 use common::{
-    ado_base::query_get,
-    encode_binary,
-    error::ContractError,
-    primitive::{AndromedaContract, GetValueResponse},
+    ado_base::query_get, encode_binary, error::ContractError, primitive::GetValueResponse,
 };
 use cosmwasm_std::{QuerierWrapper, Storage};
 
 impl<'a> ADOContract<'a> {
-    pub fn get_address(
+    /// Gets the value of `contract` in `self.cached_addresses`.
+    pub fn get_cached_address(
+        &self,
+        storage: &dyn Storage,
+        contract: &str,
+    ) -> Result<String, ContractError> {
+        Ok(self.cached_addresses.load(storage, contract)?)
+    }
+
+    /// Queries the primitive contract to get the [`String`] stored with key `contract`. The result
+    /// is then stored in `self.cached_addresses` to be read later.
+    pub fn cache_address(
+        &self,
+        storage: &mut dyn Storage,
+        querier: &QuerierWrapper,
+        contract: &str,
+    ) -> Result<(), ContractError> {
+        let address = self.get_address_from_primitive(storage, querier, contract)?;
+        self.cached_addresses.save(storage, contract, &address)?;
+        Ok(())
+    }
+
+    pub(crate) fn get_address_from_primitive(
         &self,
         storage: &dyn Storage,
         querier: &QuerierWrapper,
-        contract: AndromedaContract,
+        contract: &str,
     ) -> Result<String, ContractError> {
-        let address = self.primitive_contract.load(storage)?;
-        let data = encode_binary(&contract.to_string())?;
-        let res: GetValueResponse = query_get(Some(data), address.to_string(), querier)?;
-        Ok(res.value.try_get_string()?)
+        let primitive_address = self.primitive_contract.load(storage)?;
+        let data = encode_binary(&contract)?;
+        let res: GetValueResponse = query_get(Some(data), primitive_address.to_string(), querier)?;
+        let address = res.value.try_get_string()?;
+
+        Ok(address)
     }
 }

--- a/packages/ado_base/src/primitive.rs
+++ b/packages/ado_base/src/primitive.rs
@@ -74,7 +74,7 @@ impl<'a> ADOContract<'a> {
             .collect::<Result<Vec<String>, _>>()?;
 
         for key in keys.iter() {
-            self.cache_address(deps.storage, &deps.querier, &key)?;
+            self.cache_address(deps.storage, &deps.querier, key)?;
         }
 
         Ok(Response::new()

--- a/packages/ado_base/src/query.rs
+++ b/packages/ado_base/src/query.rs
@@ -15,6 +15,7 @@ use serde::de::DeserializeOwned;
 type QueryFunction<Q> = fn(Deps, Env, Q) -> Result<Binary, ContractError>;
 
 impl<'a> ADOContract<'a> {
+    #[allow(unreachable_patterns)]
     pub fn query<Q: DeserializeOwned>(
         &self,
         deps: Deps,
@@ -33,20 +34,11 @@ impl<'a> ADOContract<'a> {
             AndromedaQuery::IsOperator { address } => {
                 encode_binary(&self.query_is_operator(deps, &address)?)
             }
-            AndromedaQuery::Module { id } => {
-                #[cfg(feature = "modules")]
-                return encode_binary(&self.query_module(deps, id)?);
-
-                #[cfg(not(feature = "modules"))]
-                return Err(ContractError::UnsupportedOperation {});
-            }
-            AndromedaQuery::ModuleIds {} => {
-                #[cfg(feature = "modules")]
-                return encode_binary(&self.query_module_ids(deps)?);
-
-                #[cfg(not(feature = "modules"))]
-                return Err(ContractError::UnsupportedOperation {});
-            }
+            #[cfg(feature = "modules")]
+            AndromedaQuery::Module { id } => encode_binary(&self.query_module(deps, id)?),
+            #[cfg(feature = "modules")]
+            AndromedaQuery::ModuleIds {} => encode_binary(&self.query_module_ids(deps)?),
+            _ => Err(ContractError::UnsupportedOperation {}),
         }
     }
 }

--- a/packages/ado_base/src/state.rs
+++ b/packages/ado_base/src/state.rs
@@ -12,6 +12,8 @@ pub struct ADOContract<'a> {
     pub ado_type: Item<'a, String>,
     #[cfg(feature = "primitive")]
     pub primitive_contract: Item<'a, Addr>,
+    #[cfg(feature = "primitive")]
+    pub(crate) cached_addresses: Map<'a, &'a str, String>,
     #[cfg(feature = "modules")]
     pub module_info: Map<'a, &'a str, Module>,
     #[cfg(feature = "modules")]
@@ -30,6 +32,8 @@ impl<'a> Default for ADOContract<'a> {
             ado_type: Item::new("ado_type"),
             #[cfg(feature = "primitive")]
             primitive_contract: Item::new("primitive_contract"),
+            #[cfg(feature = "primitive")]
+            cached_addresses: Map::new("cached_addresses"),
             #[cfg(feature = "modules")]
             module_info: Map::new("andr_modules"),
             #[cfg(feature = "modules")]

--- a/packages/andromeda_protocol/src/anchor.rs
+++ b/packages/andromeda_protocol/src/anchor.rs
@@ -14,9 +14,7 @@ pub enum WithdrawalType {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
-    pub anchor_market: String,
-    pub anchor_bluna_hub: String,
-    pub anchor_bluna_custody: String,
+    pub primitive_contract: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -64,18 +62,6 @@ pub struct MigrateMsg {}
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     AndrQuery(AndromedaQuery),
-    Config {},
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct ConfigResponse {
-    pub anchor_market: String,
-    pub aust_token: String,
-    pub anchor_bluna_hub: String,
-    pub anchor_bluna_custody: String,
-    pub anchor_overseer: String,
-    pub bluna_token: String,
-    pub anchor_oracle: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/common/src/ado_base/mod.rs
+++ b/packages/common/src/ado_base/mod.rs
@@ -46,6 +46,13 @@ pub enum AndromedaMsg {
         module_idx: Uint64,
         module: Module,
     },
+    RefreshAddress {
+        contract: String,
+    },
+    RefreshAddresses {
+        limit: Option<u32>,
+        start_after: Option<String>,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/packages/common/src/primitive.rs
+++ b/packages/common/src/primitive.rs
@@ -1,21 +1,6 @@
 use cosmwasm_std::{Coin, Decimal, StdError, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::fmt;
-
-/// Enum of possible contracts whose addresses we want to store in a primitive contract.
-pub enum AndromedaContract {
-    Factory,
-}
-
-impl fmt::Display for AndromedaContract {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let string = match self {
-            AndromedaContract::Factory => "factory",
-        };
-        write!(f, "{}", string)
-    }
-}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
# Motivation
Currently, many external anchor contract addresses need to be given when instantiating the Anchor ADO. These addresses are the same across every Anchor ADO so it doesn't make sense to define them for each instance. The solution I chose was to store them in the Primitive contract and reference them with queries. This way we only ever need to store them once, rather than each time someone wants to instantiate an Anchor ADO. 

# Implementation
I added a file `primitive_keys.rs` to the anchor contract. This file exports constant strings that represent the possible contracts that are stored in the primitive contract. For example, one of these is `ANCHOR_MONEY_MARKET`. Since these addresses are VERY unlikely to change (probably only when the chain has a massive upgrade like col5, and maybe not even then), I added caching to only query the contracts once. This was done by adding a `cached_addresses: Map<&str, String>` to `ADOContract`. In the instantiate method of the Anchor ADO, it calls `ADOContract::default().cache_address(..., address)` for each address it wants to cache. This call queries the primitive contract and stores the result in the aforementioned map. After this is done, the addresses can be read throughout the contract using `ADOContract::default().get_cached_address(...,address)` which will read from the map.

In case the addresses need to update, I added two new variants to the `AndromedaMsg` enum: `RefreshAddress { address }` and `RefreshAddresses { start_after, limit }`, which can do that. 

# Testing

## Unit/Integration tests
I updated the existing tests for the Anchor ADO which all pass. 

## On-chain tests
Not an exhaustive list but enough to get a sanity check that the mapping works.

[Instantiate](https://finder.terra.money/testnet/tx/DC8F63C195F5A030D71122AA31AB0F395DEF450A33376F42A6E99AF35A0310F2)

[Deposit UST](https://finder.terra.money/testnet/tx/08A562B3915A79531565D57A5753840B168139167304C0B91978B9ECAA251890)

[Deposit luna collateral](https://finder.terra.money/testnet/tx/F94F81F5A00901FA4ED9665E7A91C3E11B754AADD8E0976CE27CB43AEB9F4132)

# Future work
If this change is well received, we can use a similar approach for all of our proxy ADOs such as the Astroport and Mirror ADOs.