### PR TITLE
Move addresslist state to the contract from the package

### DIFF
--- a/contracts/andromeda_addresslist/src/lib.rs
+++ b/contracts/andromeda_addresslist/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod contract;
+mod state;
 #[cfg(test)]
 mod testing;

--- a/contracts/andromeda_addresslist/src/state.rs
+++ b/contracts/andromeda_addresslist/src/state.rs
@@ -1,0 +1,28 @@
+use cosmwasm_std::{StdResult, Storage};
+use cw_storage_plus::{Item, Map};
+
+pub const ADDRESS_LIST: Map<&str, bool> = Map::new("addresslist");
+pub const IS_INCLUSIVE: Item<bool> = Item::new("is_inclusive");
+
+/// Add an address to the address list.
+pub fn add_address(storage: &mut dyn Storage, addr: &str) -> StdResult<()> {
+    ADDRESS_LIST.save(storage, addr, &true)
+}
+/// Remove an address from the address list. Errors if the address is not currently included.
+pub fn remove_address(storage: &mut dyn Storage, addr: &str) {
+    // Check if the address is included in the address list before removing
+    if ADDRESS_LIST.has(storage, addr) {
+        ADDRESS_LIST.remove(storage, addr);
+    };
+}
+/// Query if a given address is included in the address list.
+pub fn includes_address(storage: &dyn Storage, addr: &str) -> StdResult<bool> {
+    match ADDRESS_LIST.load(storage, addr) {
+        Ok(included) => Ok(included),
+        Err(e) => match e {
+            //If no value for address return false
+            cosmwasm_std::StdError::NotFound { .. } => Ok(false),
+            _ => Err(e),
+        },
+    }
+}

--- a/packages/andromeda_protocol/src/address_list.rs
+++ b/packages/andromeda_protocol/src/address_list.rs
@@ -1,53 +1,6 @@
-use common::{
-    ado_base::{hooks::AndromedaHook, AndromedaMsg, AndromedaQuery},
-    error::ContractError,
-};
-use cosmwasm_std::{to_binary, QuerierWrapper, QueryRequest, StdResult, Storage, WasmQuery};
-use cw_storage_plus::{Item, Map};
+use common::ado_base::{hooks::AndromedaHook, AndromedaMsg, AndromedaQuery};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
-pub const ADDRESS_LIST: Map<String, bool> = Map::new("addresslist");
-pub const IS_INCLUSIVE: Item<bool> = Item::new("is_inclusive");
-
-/// Add an address to the address list.
-pub fn add_address(storage: &mut dyn Storage, addr: &str) -> StdResult<()> {
-    ADDRESS_LIST.save(storage, addr.to_string(), &true)
-}
-/// Remove an address from the address list. Errors if the address is not currently included.
-pub fn remove_address(storage: &mut dyn Storage, addr: &str) {
-    // Check if the address is included in the address list before removing
-    if ADDRESS_LIST.has(storage, addr.to_string()) {
-        ADDRESS_LIST.remove(storage, addr.to_string());
-    };
-}
-/// Query if a given address is included in the address list.
-pub fn includes_address(storage: &dyn Storage, addr: &str) -> StdResult<bool> {
-    match ADDRESS_LIST.load(storage, addr.to_string()) {
-        Ok(included) => Ok(included),
-        Err(e) => match e {
-            //If no value for address return false
-            cosmwasm_std::StdError::NotFound { .. } => Ok(false),
-            _ => Err(e),
-        },
-    }
-}
-
-/// Helper function to query an address list contract for inclusion of an address
-///
-/// Returns a boolean value indicating whether or not the address is included in the address list
-pub fn query_includes_address(
-    querier: QuerierWrapper,
-    contract_addr: String,
-    address: String,
-) -> Result<bool, ContractError> {
-    let res: IncludesAddressResponse = querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
-        contract_addr,
-        msg: to_binary(&QueryMsg::IncludesAddress { address })?,
-    }))?;
-
-    Ok(res.included)
-}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {

--- a/packages/andromeda_protocol/src/receipt.rs
+++ b/packages/andromeda_protocol/src/receipt.rs
@@ -13,7 +13,8 @@ pub struct Config {
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-/// A struct representation of a receipt. Contains a vector of CosmWasm [Event](https://docs.rs/cosmwasm-std/0.16.0/cosmwasm_std/struct.Event.html) structs.
+/// A struct representation of a receipt. Contains a vector of CosmWasm
+/// [Event](https://docs.rs/cosmwasm-std/0.16.0/cosmwasm_std/struct.Event.html) structs.
 pub struct Receipt {
     /// A vector of CosmWasm [Event](https://docs.rs/cosmwasm-std/0.16.0/cosmwasm_std/struct.Event.html) structs related to the receipt
     pub events: Vec<Event>,


### PR DESCRIPTION
# Motivation
An artifact of the old module structure was storing the address list as global state it the `address_list.rs` file. Since this is no longer being used outside of the contract I moved it to the `state.rs` file within the addresslist contract. 

# Implementation
I moved the state related functions and state itself to the`state.rs` file of the addresslist contract.

# Testing

## Unit/Integration tests
Just a simple refactor so none needed.

## On-chain tests
Just a simple refactor so none needed.

# Future work
None that I can think of except try to trim the package as much as possible for other contracts. 