### PR TITLE
Add base queries to cw20 and cw721 and remove now uneeded primitive contract references

### DIFF
--- a/contracts/andromeda_cw20/src/contract.rs
+++ b/contracts/andromeda_cw20/src/contract.rs
@@ -40,7 +40,7 @@ pub fn instantiate(
             ado_type: "cw20".to_string(),
             operators: None,
             modules: msg.modules.clone(),
-            primitive_contract: Some(msg.primitive_contract.clone()),
+            primitive_contract: None,
         },
     )?;
     let cw20_resp = cw20_instantiate(deps, env, info, msg.into())?;
@@ -263,5 +263,8 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
-    Ok(query_cw20(deps, env, msg.into())?)
+    match msg {
+        QueryMsg::AndrQuery(msg) => ADOContract::default().query(deps, env, msg, query),
+        _ => Ok(query_cw20(deps, env, msg.into())?),
+    }
 }

--- a/contracts/andromeda_cw20/src/testing/tests.rs
+++ b/contracts/andromeda_cw20/src/testing/tests.rs
@@ -1,14 +1,17 @@
-use crate::contract::{execute, instantiate};
+use crate::contract::{execute, instantiate, query};
 use andromeda_protocol::{
-    cw20::{ExecuteMsg, InstantiateMsg},
+    cw20::{ExecuteMsg, InstantiateMsg, QueryMsg},
     receipt::{ExecuteMsg as ReceiptExecuteMsg, Receipt},
     testing::mock_querier::{
-        mock_dependencies_custom, MOCK_ADDRESSLIST_CONTRACT, MOCK_PRIMITIVE_CONTRACT,
-        MOCK_RATES_CONTRACT, MOCK_RECEIPT_CONTRACT,
+        mock_dependencies_custom, MOCK_ADDRESSLIST_CONTRACT, MOCK_RATES_CONTRACT,
+        MOCK_RECEIPT_CONTRACT,
     },
 };
 use common::{
-    ado_base::modules::{Module, ADDRESS_LIST, RATES, RECEIPT},
+    ado_base::{
+        modules::{Module, ADDRESS_LIST, RATES, RECEIPT},
+        AndromedaQuery,
+    },
     error::ContractError,
     mission::AndrAddress,
 };
@@ -18,6 +21,32 @@ use cosmwasm_std::{
 };
 use cw20::{Cw20Coin, Cw20ReceiveMsg};
 use cw20_base::state::BALANCES;
+
+#[test]
+fn test_andr_query() {
+    let mut deps = mock_dependencies_custom(&[]);
+    let info = mock_info("owner", &[]);
+
+    let instantiate_msg = InstantiateMsg {
+        name: "Name".into(),
+        symbol: "Symbol".into(),
+        decimals: 6,
+        initial_balances: vec![Cw20Coin {
+            amount: 1000u128.into(),
+            address: "sender".to_string(),
+        }],
+        mint: None,
+        marketing: None,
+        modules: None,
+    };
+
+    let _res = instantiate(deps.as_mut(), mock_env(), info, instantiate_msg).unwrap();
+
+    let msg = QueryMsg::AndrQuery(AndromedaQuery::Owner {});
+    let res = query(deps.as_ref(), mock_env(), msg);
+    // Test that the query is hooked up correctly.
+    assert!(res.is_ok())
+}
 
 /*#
  *
@@ -176,7 +205,6 @@ fn test_transfer() {
         mint: None,
         marketing: None,
         modules: Some(modules),
-        primitive_contract: MOCK_PRIMITIVE_CONTRACT.to_owned(),
     };
 
     let res = instantiate(deps.as_mut(), mock_env(), info.clone(), instantiate_msg).unwrap();
@@ -304,7 +332,6 @@ fn test_send() {
         mint: None,
         marketing: None,
         modules: Some(modules),
-        primitive_contract: MOCK_PRIMITIVE_CONTRACT.to_owned(),
     };
 
     let res = instantiate(deps.as_mut(), mock_env(), info.clone(), instantiate_msg).unwrap();

--- a/contracts/andromeda_cw721/src/contract.rs
+++ b/contracts/andromeda_cw721/src/contract.rs
@@ -39,7 +39,7 @@ pub fn instantiate(
             ado_type: "cw721".to_string(),
             operators: None,
             modules: msg.modules.clone(),
-            primitive_contract: Some(msg.primitive_contract.clone()),
+            primitive_contract: None,
         },
     )?;
 
@@ -287,6 +287,7 @@ fn execute_burn(
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
     match msg {
         QueryMsg::AndrHook(msg) => handle_andr_hook(deps, msg),
+        QueryMsg::AndrQuery(msg) => ADOContract::default().query(deps, env, msg, query),
         _ => Ok(AndrCW721Contract::default().query(deps, env, msg.into())?),
     }
 }

--- a/contracts/andromeda_cw721/src/testing/mod.rs
+++ b/contracts/andromeda_cw721/src/testing/mod.rs
@@ -9,6 +9,7 @@ use common::{
     ado_base::{
         hooks::{AndromedaHook, OnFundsTransferResponse},
         modules::{Module, ADDRESS_LIST, OFFERS, RATES, RECEIPT},
+        AndromedaQuery,
     },
     error::ContractError,
     mission::AndrAddress,
@@ -22,7 +23,7 @@ use andromeda_protocol::{
     receipt::{ExecuteMsg as ReceiptExecuteMsg, Receipt},
     testing::mock_querier::{
         bank_sub_msg, mock_dependencies_custom, MOCK_ADDRESSLIST_CONTRACT, MOCK_OFFERS_CONTRACT,
-        MOCK_PRIMITIVE_CONTRACT, MOCK_RATES_CONTRACT, MOCK_RATES_RECIPIENT, MOCK_RECEIPT_CONTRACT,
+        MOCK_RATES_CONTRACT, MOCK_RATES_RECIPIENT, MOCK_RECEIPT_CONTRACT,
     },
 };
 use cw721::{NftInfoResponse, OwnerOfResponse};
@@ -39,7 +40,6 @@ fn init_setup(deps: DepsMut, env: Env, modules: Option<Vec<Module>>) {
         symbol: SYMBOL.to_string(),
         minter: MINTER.to_string(),
         modules,
-        primitive_contract: MOCK_PRIMITIVE_CONTRACT.to_owned(),
     };
 
     instantiate(deps, env, info, inst_msg).unwrap();
@@ -54,6 +54,17 @@ fn mint_token(deps: DepsMut, env: Env, token_id: String, owner: String, extensio
         extension,
     };
     execute(deps, env, info, ExecuteMsg::Mint(Box::new(mint_msg))).unwrap();
+}
+
+#[test]
+fn test_andr_query() {
+    let mut deps = mock_dependencies(&[]);
+    init_setup(deps.as_mut(), mock_env(), None);
+
+    let msg = QueryMsg::AndrQuery(AndromedaQuery::Owner {});
+    let res = query(deps.as_ref(), mock_env(), msg);
+    // Test that the query is hooked up correctly.
+    assert!(res.is_ok())
 }
 
 /*

--- a/contracts/andromeda_wrapped_cw721/src/contract.rs
+++ b/contracts/andromeda_wrapped_cw721/src/contract.rs
@@ -39,7 +39,7 @@ pub fn instantiate(
             ado_type: "wrapped_cw721".to_string(),
             operators: None,
             modules: None,
-            primitive_contract: Some(msg.primitive_contract.clone()),
+            primitive_contract: Some(msg.primitive_contract),
         },
     )?;
     match msg.cw721_instantiate_type {
@@ -50,7 +50,6 @@ pub fn instantiate(
                 symbol: specification.symbol,
                 modules: specification.modules,
                 minter: env.contract.address.to_string(),
-                primitive_contract: msg.primitive_contract,
             };
             let msg = contract.generate_instantiate_msg(
                 deps.storage,
@@ -323,7 +322,6 @@ mod tests {
             symbol: "symbol".to_string(),
             modules: None,
             minter: mock_env().contract.address.to_string(),
-            primitive_contract: MOCK_PRIMITIVE_CONTRACT.to_owned(),
         };
         let msg: SubMsg = SubMsg {
             id: 1,

--- a/packages/andromeda_protocol/src/cw20.rs
+++ b/packages/andromeda_protocol/src/cw20.rs
@@ -8,7 +8,7 @@ use cw20_base::msg::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use common::ado_base::{modules::Module, AndromedaMsg};
+use common::ado_base::{modules::Module, AndromedaMsg, AndromedaQuery};
 
 #[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]
 pub struct InstantiateMsg {
@@ -19,7 +19,6 @@ pub struct InstantiateMsg {
     pub mint: Option<MinterResponse>,
     pub marketing: Option<InstantiateMarketingInfo>,
     pub modules: Option<Vec<Module>>,
-    pub primitive_contract: String,
 }
 
 impl From<InstantiateMsg> for Cw20InstantiateMsg {
@@ -190,9 +189,12 @@ pub struct MigrateMsg {}
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
+    AndrQuery(AndromedaQuery),
     /// Returns the current balance of the given address, 0 if unset.
     /// Return type: BalanceResponse.
-    Balance { address: String },
+    Balance {
+        address: String,
+    },
     /// Returns metadata on the contract - name, decimals, supply, etc.
     /// Return type: TokenInfoResponse.
     TokenInfo {},
@@ -203,7 +205,10 @@ pub enum QueryMsg {
     /// Only with "allowance" extension.
     /// Returns how much spender can use from owner account, 0 if unset.
     /// Return type: AllowanceResponse.
-    Allowance { owner: String, spender: String },
+    Allowance {
+        owner: String,
+        spender: String,
+    },
     /// Only with "enumerable" extension (and "allowances")
     /// Returns all allowances this owner has approved. Supports pagination.
     /// Return type: AllAllowancesResponse.
@@ -252,6 +257,7 @@ impl From<QueryMsg> for Cw20QueryMsg {
             }
             QueryMsg::MarketingInfo {} => Cw20QueryMsg::DownloadLogo {},
             QueryMsg::DownloadLogo {} => Cw20QueryMsg::DownloadLogo {},
+            _ => panic!("Unsupported Msg"),
         }
     }
 }

--- a/packages/andromeda_protocol/src/cw721.rs
+++ b/packages/andromeda_protocol/src/cw721.rs
@@ -22,8 +22,6 @@ pub struct InstantiateMsg {
     pub minter: String,
     ///The attached Andromeda modules
     pub modules: Option<Vec<Module>>,
-    /// The primitive contract address used to retrieve contract addresses.
-    pub primitive_contract: String,
 }
 
 impl From<InstantiateMsg> for Cw721InstantiateMsg {


### PR DESCRIPTION
# Motivation
When implementing the cw20 and cw721 contracts we overlooked adding the base `AndromedaQuery` queries which should be present in all ADOs (thanks to @daniel-wehbe for spotting this!). We also used to require a reference to the primitive contract in both of these ADOs when modules were instantiated, but now it is unneeded. 

# Implementation
As stated in the motivation.

# Testing

## Unit/Integration tests
I added a unit test for both cw20 and cw721 that ensure that the base queries work correctly. 

## On-chain tests
Not necessary. 

# Future work
None that I can think of. 