### PR TITLE
Replace 'name' with 'key' in primitive contract

### DIFF
--- a/contracts/andromeda_anchor/src/testing/mock_querier.rs
+++ b/contracts/andromeda_anchor/src/testing/mock_querier.rs
@@ -154,37 +154,37 @@ impl WasmMockQuerier {
     fn handle_primitive_query(&self, msg: &Binary) -> QuerierResult {
         match from_binary(msg).unwrap() {
             PrimitiveQueryMsg::AndrQuery(AndromedaQuery::Get(data)) => {
-                let name: String = from_binary(&data.unwrap()).unwrap();
-                let msg_response = match name.as_str() {
+                let key: String = from_binary(&data.unwrap()).unwrap();
+                let msg_response = match key.as_str() {
                     ANCHOR_MARKET => GetValueResponse {
-                        name,
+                        key,
                         value: Primitive::String(MOCK_MARKET_CONTRACT.to_owned()),
                     },
                     ANCHOR_OVERSEER => GetValueResponse {
-                        name,
+                        key,
                         value: Primitive::String(MOCK_OVERSEER_CONTRACT.to_owned()),
                     },
                     ANCHOR_BLUNA_HUB => GetValueResponse {
-                        name,
+                        key,
                         value: Primitive::String(MOCK_BLUNA_HUB_CONTRACT.to_owned()),
                     },
                     ANCHOR_BLUNA_CUSTODY => GetValueResponse {
-                        name,
+                        key,
                         value: Primitive::String(MOCK_CUSTODY_CONTRACT.to_owned()),
                     },
                     ANCHOR_ORACLE => GetValueResponse {
-                        name,
+                        key,
                         value: Primitive::String(MOCK_ORACLE_CONTRACT.to_owned()),
                     },
                     ANCHOR_AUST => GetValueResponse {
-                        name,
+                        key,
                         value: Primitive::String(MOCK_AUST_TOKEN.to_owned()),
                     },
                     ANCHOR_BLUNA => GetValueResponse {
-                        name,
+                        key,
                         value: Primitive::String(MOCK_BLUNA_TOKEN.to_owned()),
                     },
-                    _ => panic!("Unsupported primitive name"),
+                    _ => panic!("Unsupported primitive key"),
                 };
                 SystemResult::Ok(ContractResult::Ok(to_binary(&msg_response).unwrap()))
             }

--- a/contracts/andromeda_mirror_wrapped_cdp/src/testing/mock_querier.rs
+++ b/contracts/andromeda_mirror_wrapped_cdp/src/testing/mock_querier.rs
@@ -131,29 +131,29 @@ impl WasmMockQuerier {
     fn handle_primitive_query(&self, msg: &Binary) -> QuerierResult {
         match from_binary(msg).unwrap() {
             PrimitiveQueryMsg::AndrQuery(AndromedaQuery::Get(data)) => {
-                let name: String = from_binary(&data.unwrap()).unwrap();
-                let msg_response = match name.as_str() {
+                let key: String = from_binary(&data.unwrap()).unwrap();
+                let msg_response = match key.as_str() {
                     MIRROR_MINT => GetValueResponse {
-                        name,
+                        key,
                         value: Primitive::String(MOCK_MIRROR_MINT_ADDR.to_owned()),
                     },
                     MIRROR_STAKING => GetValueResponse {
-                        name,
+                        key,
                         value: Primitive::String(MOCK_MIRROR_STAKING_ADDR.to_owned()),
                     },
                     MIRROR_GOV => GetValueResponse {
-                        name,
+                        key,
                         value: Primitive::String(MOCK_MIRROR_GOV_ADDR.to_owned()),
                     },
                     MIRROR_LOCK => GetValueResponse {
-                        name,
+                        key,
                         value: Primitive::String(MOCK_MIRROR_LOCK_ADDR.to_owned()),
                     },
                     MIRROR_MIR => GetValueResponse {
-                        name,
+                        key,
                         value: Primitive::String(MOCK_MIRROR_TOKEN_ADDR.to_owned()),
                     },
-                    _ => panic!("Unsupported primitive name"),
+                    _ => panic!("Unsupported primitive key"),
                 };
                 SystemResult::Ok(ContractResult::Ok(to_binary(&msg_response).unwrap()))
             }

--- a/packages/ado_base/src/mock_querier.rs
+++ b/packages/ado_base/src/mock_querier.rs
@@ -78,17 +78,17 @@ impl WasmMockQuerier {
     fn handle_primitive_query(&self, msg: &Binary) -> QuerierResult {
         match from_binary(msg).unwrap() {
             QueryMsg::AndrQuery(AndromedaQuery::Get(data)) => {
-                let name: String = from_binary(&data.unwrap()).unwrap();
-                let msg_response = match name.as_str() {
+                let key: String = from_binary(&data.unwrap()).unwrap();
+                let msg_response = match key.as_str() {
                     "key1" => GetValueResponse {
-                        name,
+                        key,
                         value: Primitive::String("address1".to_string()),
                     },
                     "key2" => GetValueResponse {
-                        name,
+                        key,
                         value: Primitive::String("address2".to_string()),
                     },
-                    _ => panic!("Unsupported primitive name"),
+                    _ => panic!("Unsupported primitive key"),
                 };
                 SystemResult::Ok(ContractResult::Ok(to_binary(&msg_response).unwrap()))
             }

--- a/packages/andromeda_protocol/src/primitive.rs
+++ b/packages/andromeda_protocol/src/primitive.rs
@@ -2,7 +2,6 @@ use common::{
     ado_base::{AndromedaMsg, AndromedaQuery},
     primitive::Primitive,
 };
-use cosmwasm_std::Addr;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -15,14 +14,14 @@ pub struct InstantiateMsg {
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
     AndrReceive(AndromedaMsg),
-    /// If name is not specified the default key will be used.
+    /// If key is not specified the default key will be used.
     SetValue {
-        name: Option<String>,
+        key: Option<String>,
         value: Primitive,
     },
-    /// If name is not specified the default key will be used.
+    /// If key is not specified the default key will be used.
     DeleteValue {
-        name: Option<String>,
+        key: Option<String>,
     },
 }
 
@@ -34,9 +33,4 @@ pub struct MigrateMsg {}
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     AndrQuery(AndromedaQuery),
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct ConfigResponse {
-    pub owner: Addr,
 }

--- a/packages/andromeda_protocol/src/testing/mock_querier.rs
+++ b/packages/andromeda_protocol/src/testing/mock_querier.rs
@@ -412,25 +412,25 @@ impl WasmMockQuerier {
     fn handle_primitive_query(&self, msg: &Binary) -> QuerierResult {
         match from_binary(msg).unwrap() {
             PrimitiveQueryMsg::AndrQuery(AndromedaQuery::Get(data)) => {
-                let name: String = from_binary(&data.unwrap()).unwrap();
-                let msg_response = match name.as_str() {
+                let key: String = from_binary(&data.unwrap()).unwrap();
+                let msg_response = match key.as_str() {
                     "percent" => GetValueResponse {
-                        name,
+                        key,
                         value: Primitive::Decimal(Decimal::percent(1)),
                     },
                     "flat" => GetValueResponse {
-                        name,
+                        key,
                         value: Primitive::Coin(coin(1u128, "uusd")),
                     },
                     "flat_cw20" => GetValueResponse {
-                        name,
+                        key,
                         value: Primitive::Coin(coin(1u128, "address")),
                     },
                     "factory" => GetValueResponse {
-                        name,
+                        key,
                         value: Primitive::String(MOCK_FACTORY_CONTRACT.to_owned()),
                     },
-                    _ => panic!("Unsupported primitive name"),
+                    _ => panic!("Unsupported primitive key"),
                 };
                 SystemResult::Ok(ContractResult::Ok(to_binary(&msg_response).unwrap()))
             }

--- a/packages/common/src/primitive.rs
+++ b/packages/common/src/primitive.rs
@@ -71,7 +71,7 @@ impl Primitive {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct GetValueResponse {
-    pub name: String,
+    pub key: String,
     pub value: Primitive,
 }
 


### PR DESCRIPTION
# Motivation
Prior to this change we referred to a primitive identifier as either "key" or "name" which has lead to confusion. Therefore I decided to change all code references to 'key' for consistency. 

# Implementation
Replace all instances of "name" with "key". There might be some rogue references about but I got the majority of them. 

# Testing

## Unit/Integration tests
Just updated existing tests.

## On-chain tests
None necessary.

# Future work
None.