### PR TITLE
CU-277m0w8 | Add checks that received cw20 amounts are non-zero

### DIFF
--- a/contracts/andromeda_anchor/src/contract.rs
+++ b/contracts/andromeda_anchor/src/contract.rs
@@ -129,6 +129,13 @@ pub fn receive_cw20(
     info: MessageInfo,
     cw20_msg: Cw20ReceiveMsg,
 ) -> Result<Response, ContractError> {
+    require(
+        !cw20_msg.amount.is_zero(),
+        ContractError::InvalidFunds {
+            msg: "Amount must be non-zero".to_string(),
+        },
+    )?;
+
     match from_binary(&cw20_msg.msg)? {
         Cw20HookMsg::DepositCollateral {} => execute_deposit_collateral_to_anchor(
             deps,

--- a/contracts/andromeda_anchor/src/testing/tests.rs
+++ b/contracts/andromeda_anchor/src/testing/tests.rs
@@ -1249,3 +1249,25 @@ fn test_withdraw_collateral_unauthorized() {
     let res = execute(deps.as_mut(), mock_env(), info, msg);
     assert_eq!(ContractError::Unauthorized {}, res.unwrap_err());
 }
+
+#[test]
+fn test_receive_cw20_zero_amount() {
+    let mut deps = mock_dependencies_custom(&[]);
+    init(deps.as_mut());
+
+    let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
+        sender: "sender".to_string(),
+        amount: Uint128::zero(),
+        msg: to_binary(&"").unwrap(),
+    });
+
+    let info = mock_info(MOCK_BLUNA_TOKEN, &[]);
+    let res = execute(deps.as_mut(), mock_env(), info, msg);
+
+    assert_eq!(
+        ContractError::InvalidFunds {
+            msg: "Amount must be non-zero".to_string()
+        },
+        res.unwrap_err()
+    );
+}

--- a/contracts/andromeda_astroport/src/contract.rs
+++ b/contracts/andromeda_astroport/src/contract.rs
@@ -299,6 +299,13 @@ pub fn receive_cw20(
     info: MessageInfo,
     cw20_msg: Cw20ReceiveMsg,
 ) -> Result<Response, ContractError> {
+    require(
+        !cw20_msg.amount.is_zero(),
+        ContractError::InvalidFunds {
+            msg: "Amount must be non-zero".to_string(),
+        },
+    )?;
+
     let config = CONFIG.load(deps.storage)?;
     let token_address = info.sender;
     match from_binary(&cw20_msg.msg)? {

--- a/contracts/andromeda_astroport/src/testing/tests.rs
+++ b/contracts/andromeda_astroport/src/testing/tests.rs
@@ -21,7 +21,7 @@ use common::error::ContractError;
 use cosmwasm_std::{
     coins,
     testing::{mock_env, mock_info},
-    to_binary, Addr, BankMsg, CosmosMsg, DepsMut, Response, SubMsg, WasmMsg,
+    to_binary, Addr, BankMsg, CosmosMsg, DepsMut, Response, SubMsg, Uint128, WasmMsg,
 };
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use cw_asset::{Asset, AssetInfo};
@@ -512,4 +512,26 @@ fn test_withdraw_liquidity_unauthorized() {
     let info = mock_info("anyone", &[]);
     let res = execute(deps.as_mut(), mock_env(), info, msg);
     assert_eq!(ContractError::Unauthorized {}, res.unwrap_err());
+}
+
+#[test]
+fn test_receive_cw20_zero_amount() {
+    let mut deps = mock_dependencies_custom(&[]);
+    init(deps.as_mut());
+
+    let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
+        sender: "sender".to_string(),
+        amount: Uint128::zero(),
+        msg: to_binary(&"").unwrap(),
+    });
+
+    let info = mock_info(MOCK_LP_TOKEN_CONTRACT, &[]);
+    let res = execute(deps.as_mut(), mock_env(), info, msg);
+
+    assert_eq!(
+        ContractError::InvalidFunds {
+            msg: "Amount must be non-zero".to_string()
+        },
+        res.unwrap_err()
+    );
 }

--- a/contracts/andromeda_mirror_wrapped_cdp/src/contract.rs
+++ b/contracts/andromeda_mirror_wrapped_cdp/src/contract.rs
@@ -244,6 +244,13 @@ pub fn receive_cw20(
     info: MessageInfo,
     cw20_msg: Cw20ReceiveMsg,
 ) -> Result<Response, ContractError> {
+    require(
+        !cw20_msg.amount.is_zero(),
+        ContractError::InvalidFunds {
+            msg: "Amount must be non-zero".to_string(),
+        },
+    )?;
+
     let contract = ADOContract::default();
     let mirror_staking_contract = contract.get_cached_address(deps.storage, MIRROR_STAKING)?;
     let mirror_gov_contract = contract.get_cached_address(deps.storage, MIRROR_GOV)?;

--- a/contracts/andromeda_mirror_wrapped_cdp/src/testing/tests.rs
+++ b/contracts/andromeda_mirror_wrapped_cdp/src/testing/tests.rs
@@ -883,7 +883,7 @@ fn test_mirror_andr_receive() {
 fn test_receive_cw20_zero_amount() {
     let mut deps = mock_dependencies_custom(&[]);
     let info = mock_info("creator", &[]);
-    assert_intantiate(deps.as_mut(), info.clone());
+    assert_intantiate(deps.as_mut(), info);
 
     let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
         sender: "sender".to_string(),

--- a/contracts/andromeda_mirror_wrapped_cdp/src/testing/tests.rs
+++ b/contracts/andromeda_mirror_wrapped_cdp/src/testing/tests.rs
@@ -878,3 +878,26 @@ fn test_mirror_andr_receive() {
         res
     );
 }
+
+#[test]
+fn test_receive_cw20_zero_amount() {
+    let mut deps = mock_dependencies_custom(&[]);
+    let info = mock_info("creator", &[]);
+    assert_intantiate(deps.as_mut(), info.clone());
+
+    let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
+        sender: "sender".to_string(),
+        amount: Uint128::zero(),
+        msg: to_binary(&"").unwrap(),
+    });
+
+    let info = mock_info(TEST_TOKEN, &[]);
+    let res = execute(deps.as_mut(), mock_env(), info, msg);
+
+    assert_eq!(
+        ContractError::InvalidFunds {
+            msg: "Amount must be non-zero".to_string()
+        },
+        res.unwrap_err()
+    );
+}

--- a/contracts/andromeda_swapper/src/contract.rs
+++ b/contracts/andromeda_swapper/src/contract.rs
@@ -204,6 +204,13 @@ pub fn receive_cw20(
     info: MessageInfo,
     cw20_msg: Cw20ReceiveMsg,
 ) -> Result<Response, ContractError> {
+    require(
+        !cw20_msg.amount.is_zero(),
+        ContractError::InvalidFunds {
+            msg: "Amount must be non-zero".to_string(),
+        },
+    )?;
+
     match from_binary(&cw20_msg.msg)? {
         Cw20HookMsg::Swap {
             ask_asset_info,

--- a/contracts/andromeda_swapper/src/testing/tests.rs
+++ b/contracts/andromeda_swapper/src/testing/tests.rs
@@ -10,7 +10,7 @@ use common::{ado_base::recipient::Recipient, error::ContractError};
 use cosmwasm_std::{
     coins,
     testing::{mock_env, mock_info},
-    to_binary, Addr, BankMsg, CosmosMsg, DepsMut, ReplyOn, Response, SubMsg, WasmMsg,
+    to_binary, Addr, BankMsg, CosmosMsg, DepsMut, ReplyOn, Response, SubMsg, Uint128, WasmMsg,
 };
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use cw_asset::AssetInfo;
@@ -406,5 +406,27 @@ fn test_swap_cw20_to_cw20() {
                 funds: vec![],
             })),
         res
+    );
+}
+
+#[test]
+fn test_receive_cw20_zero_amount() {
+    let mut deps = mock_dependencies_custom(&[]);
+    init(deps.as_mut());
+
+    let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
+        sender: "sender".to_string(),
+        amount: Uint128::zero(),
+        msg: to_binary(&"").unwrap(),
+    });
+
+    let info = mock_info(MOCK_CW20_CONTRACT, &[]);
+    let res = execute(deps.as_mut(), mock_env(), info, msg);
+
+    assert_eq!(
+        ContractError::InvalidFunds {
+            msg: "Amount must be non-zero".to_string()
+        },
+        res.unwrap_err()
     );
 }


### PR DESCRIPTION
# Motivation
This check is already handled by the cw20-base contract, but there isn't a reason why someone can't make their own contract without this check. Therefore, in every contract that we can receive funds, we should check that the funds are non-zero.

# Implementation
I added a simple `require` statement in every `cw20_receive` function to check that the amount is non-zero. 

# Testing

## Unit/Integration tests
Every modified contract also got a test to ensure that zero funds were invalid. 

## On-chain tests
None necessary. 

# Future work
None.