### PR TITLE
Add token queries to crowdfund

### DIFF
--- a/contracts/andromeda_crowdfund/src/contract.rs
+++ b/contracts/andromeda_crowdfund/src/contract.rs
@@ -1,5 +1,6 @@
 use crate::state::{
-    Config, Purchase, State, AVAILABLE_TOKENS, CONFIG, PURCHASES, SALE_CONDUCTED, STATE,
+    get_available_tokens, Config, Purchase, State, AVAILABLE_TOKENS, CONFIG, PURCHASES,
+    SALE_CONDUCTED, STATE,
 };
 use ado_base::ADOContract;
 use andromeda_protocol::{
@@ -595,6 +596,10 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
         QueryMsg::AndrQuery(msg) => ADOContract::default().query(deps, env, msg, query),
         QueryMsg::State {} => encode_binary(&query_state(deps)?),
         QueryMsg::Config {} => encode_binary(&query_config(deps)?),
+        QueryMsg::AvailableTokens { start_after, limit } => {
+            encode_binary(&query_available_tokens(deps, start_after, limit)?)
+        }
+        QueryMsg::IsTokenAvailable { id } => encode_binary(&query_is_token_available(deps, id)),
     }
 }
 
@@ -604,4 +609,16 @@ fn query_state(deps: Deps) -> Result<State, ContractError> {
 
 fn query_config(deps: Deps) -> Result<Config, ContractError> {
     Ok(CONFIG.load(deps.storage)?)
+}
+
+fn query_available_tokens(
+    deps: Deps,
+    start_after: Option<String>,
+    limit: Option<u32>,
+) -> Result<Vec<String>, ContractError> {
+    get_available_tokens(deps, start_after, limit)
+}
+
+fn query_is_token_available(deps: Deps, id: String) -> bool {
+    AVAILABLE_TOKENS.has(deps.storage, &id)
 }

--- a/contracts/andromeda_crowdfund/src/state.rs
+++ b/contracts/andromeda_crowdfund/src/state.rs
@@ -79,5 +79,5 @@ pub(crate) fn get_available_tokens(
             Ok(token)
         })
         .collect();
-    Ok(tokens?)
+    tokens
 }

--- a/contracts/andromeda_crowdfund/src/state.rs
+++ b/contracts/andromeda_crowdfund/src/state.rs
@@ -1,7 +1,7 @@
-use common::{ado_base::recipient::Recipient, mission::AndrAddress};
-use cosmwasm_std::{Coin, SubMsg, Uint128};
+use common::{ado_base::recipient::Recipient, error::ContractError, mission::AndrAddress};
+use cosmwasm_std::{Coin, Deps, Order, SubMsg, Uint128};
 use cw0::Expiration;
-use cw_storage_plus::{Item, Map};
+use cw_storage_plus::{Bound, Item, Map};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -60,4 +60,24 @@ pub struct State {
     pub amount_transferred: Uint128,
     /// The recipient of the raised funds if the sale is successful.
     pub recipient: Recipient,
+}
+
+const MAX_LIMIT: u32 = 50;
+const DEFAULT_LIMIT: u32 = 20;
+pub(crate) fn get_available_tokens(
+    deps: Deps,
+    start_after: Option<String>,
+    limit: Option<u32>,
+) -> Result<Vec<String>, ContractError> {
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+    let start = start_after.map(Bound::exclusive);
+    let tokens: Result<Vec<String>, ContractError> = AVAILABLE_TOKENS
+        .keys(deps.storage, start, None, Order::Ascending)
+        .take(limit)
+        .map(|v| {
+            let token = String::from_utf8(v)?;
+            Ok(token)
+        })
+        .collect();
+    Ok(tokens?)
 }

--- a/contracts/andromeda_crowdfund/src/testing/tests.rs
+++ b/contracts/andromeda_crowdfund/src/testing/tests.rs
@@ -1,5 +1,5 @@
 use crate::{
-    contract::{execute, instantiate},
+    contract::{execute, instantiate, query},
     state::{Config, Purchase, State, AVAILABLE_TOKENS, CONFIG, PURCHASES, SALE_CONDUCTED, STATE},
     testing::mock_querier::{
         mock_dependencies_custom, MOCK_CONDITIONS_MET_CONTRACT, MOCK_CONDITIONS_NOT_MET_CONTRACT,
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 use andromeda_protocol::{
-    crowdfund::{ExecuteMsg, InstantiateMsg},
+    crowdfund::{ExecuteMsg, InstantiateMsg, QueryMsg},
     cw721::{ExecuteMsg as Cw721ExecuteMsg, MintMsg, TokenExtension},
 };
 use common::{
@@ -21,7 +21,7 @@ use common::{
     mission::AndrAddress,
 };
 use cosmwasm_std::{
-    coin, coins,
+    coin, coins, from_binary,
     testing::{mock_env, mock_info},
     Addr, BankMsg, Coin, CosmosMsg, DepsMut, Response, SubMsg, Uint128, WasmMsg,
 };
@@ -658,6 +658,36 @@ fn test_multiple_purchases() {
     mint(deps.as_mut(), MOCK_TOKENS_FOR_SALE[1]).unwrap();
     mint(deps.as_mut(), MOCK_TOKENS_FOR_SALE[2]).unwrap();
 
+    // Query available tokens.
+    let msg = QueryMsg::AvailableTokens {
+        start_after: None,
+        limit: None,
+    };
+    let res: Vec<String> = from_binary(&query(deps.as_ref(), mock_env(), msg).unwrap()).unwrap();
+    assert_eq!(
+        vec![
+            MOCK_TOKENS_FOR_SALE[0],
+            MOCK_TOKENS_FOR_SALE[1],
+            MOCK_TOKENS_FOR_SALE[2]
+        ],
+        res
+    );
+
+    // Query if individual token is available
+    let msg = QueryMsg::IsTokenAvailable {
+        id: MOCK_TOKENS_FOR_SALE[0].to_owned(),
+    };
+    let res: bool = from_binary(&query(deps.as_ref(), mock_env(), msg).unwrap()).unwrap();
+    assert!(res);
+
+    // Query if another token is available
+    let msg = QueryMsg::IsTokenAvailable {
+        id: MOCK_TOKENS_FOR_SALE[3].to_owned(),
+    };
+    let res: bool = from_binary(&query(deps.as_ref(), mock_env(), msg).unwrap()).unwrap();
+    assert!(!res);
+
+    // Purchase token
     let msg = ExecuteMsg::Purchase {
         token_id: MOCK_TOKENS_FOR_SALE[0].to_owned(),
     };

--- a/packages/andromeda_protocol/src/crowdfund.rs
+++ b/packages/andromeda_protocol/src/crowdfund.rs
@@ -54,4 +54,11 @@ pub enum QueryMsg {
     AndrQuery(AndromedaQuery),
     State {},
     Config {},
+    AvailableTokens {
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+    IsTokenAvailable {
+        id: String,
+    },
 }


### PR DESCRIPTION
# Motivation
This PR contains two new queries: one that gets all available tokens for sale and another that checks that a given token is available. Both are necessary to be able to interact with the contract with a frontend. 

# Implementation
Nothing novel here. 

# Testing

## Unit/Integration tests
I added the two queries into existing tests to ensure that they work. 

## On-chain tests
No since they are unnecessary. 

# Future work
We may also want to add support for purchasing multiple tokens in a single transaction but we need to discuss if it is worth the extra complexity. 