### PR TITLE
Remove pricing from token extension

### DIFF
--- a/contracts/andromeda_crowdfund/schema/execute_msg.json
+++ b/contracts/andromeda_crowdfund/schema/execute_msg.json
@@ -22,7 +22,10 @@
       ],
       "properties": {
         "mint": {
-          "$ref": "#/definitions/MintMsg_for_TokenExtension"
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CrowdfundMintMsg"
+          }
         }
       },
       "additionalProperties": false
@@ -53,14 +56,12 @@
             },
             "max_amount_per_wallet": {
               "description": "The amount of tokens a wallet can purchase, default is 1.",
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Uint128"
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
             },
             "min_tokens_sold": {
               "description": "The minimum amount of tokens sold to go through with the sale.",
@@ -92,13 +93,36 @@
       "additionalProperties": false
     },
     {
-      "description": "Puchases a token in an ongoing sale.",
+      "description": "Puchases tokens in an ongoing sale.",
       "type": "object",
       "required": [
         "purchase"
       ],
       "properties": {
         "purchase": {
+          "type": "object",
+          "properties": {
+            "number_of_tokens": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Purchases the token with the given id.",
+      "type": "object",
+      "required": [
+        "purchase_by_token_id"
+      ],
+      "properties": {
+        "purchase_by_token_id": {
           "type": "object",
           "required": [
             "token_id"
@@ -440,6 +464,41 @@
         }
       }
     },
+    "CrowdfundMintMsg": {
+      "type": "object",
+      "required": [
+        "extension",
+        "token_id"
+      ],
+      "properties": {
+        "extension": {
+          "description": "Any custom extension used by this contract",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TokenExtension"
+            }
+          ]
+        },
+        "owner": {
+          "description": "The owner of the newly minter NFT",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "token_id": {
+          "description": "Unique ID of the NFT",
+          "type": "string"
+        },
+        "token_uri": {
+          "description": "Universal resource identifier for this NFT Should point to a JSON file that conforms to the ERC721 Metadata JSON Schema",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
       "oneOf": [
@@ -521,39 +580,6 @@
         "json",
         "other"
       ]
-    },
-    "MintMsg_for_TokenExtension": {
-      "type": "object",
-      "required": [
-        "extension",
-        "owner",
-        "token_id"
-      ],
-      "properties": {
-        "extension": {
-          "description": "Any custom extension used by this contract",
-          "allOf": [
-            {
-              "$ref": "#/definitions/TokenExtension"
-            }
-          ]
-        },
-        "owner": {
-          "description": "The owner of the newly minter NFT",
-          "type": "string"
-        },
-        "token_id": {
-          "description": "Unique ID of the NFT",
-          "type": "string"
-        },
-        "token_uri": {
-          "description": "Universal resource identifier for this NFT Should point to a JSON file that conforms to the ERC721 Metadata JSON Schema",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      }
     },
     "Module": {
       "description": "Modules can be instantiated in two different ways New - Provide an instantiation message for the contract, a new contract will be instantiated and the address recorded Address - Provide an address for an already instantiated module contract A struct describing a token module, provided with the instantiation message this struct is used to record the info about the module and how/if it should be instantiated",
@@ -645,17 +671,6 @@
         "name": {
           "description": "The name of the token",
           "type": "string"
-        },
-        "pricing": {
-          "description": "The current price listing for the token",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Coin"
-            },
-            {
-              "type": "null"
-            }
-          ]
         },
         "publisher": {
           "description": "The original publisher of the token (immutable)",

--- a/contracts/andromeda_crowdfund/src/testing/tests.rs
+++ b/contracts/andromeda_crowdfund/src/testing/tests.rs
@@ -146,7 +146,6 @@ fn test_mint_unauthorized() {
             transfer_agreement: None,
             metadata: None,
             archived: false,
-            pricing: None,
         },
     }]);
     let info = mock_info("not_owner", &[]);
@@ -171,7 +170,6 @@ fn test_mint_owner_not_crowdfund() {
             transfer_agreement: None,
             metadata: None,
             archived: false,
-            pricing: None,
         },
     }]);
     let info = mock_info("owner", &[]);
@@ -256,7 +254,6 @@ fn test_mint_successful() {
             transfer_agreement: None,
             metadata: None,
             archived: false,
-            pricing: None,
         },
     });
 
@@ -291,7 +288,6 @@ fn test_mint_multiple_successful() {
                 transfer_agreement: None,
                 metadata: None,
                 archived: false,
-                pricing: None,
             },
         },
         CrowdfundMintMsg {
@@ -305,7 +301,6 @@ fn test_mint_multiple_successful() {
                 transfer_agreement: None,
                 metadata: None,
                 archived: false,
-                pricing: None,
             },
         },
     ];
@@ -330,7 +325,6 @@ fn test_mint_multiple_successful() {
                         transfer_agreement: None,
                         metadata: None,
                         archived: false,
-                        pricing: None,
                     },
                 },)))
                 .unwrap(),
@@ -349,7 +343,6 @@ fn test_mint_multiple_successful() {
                         transfer_agreement: None,
                         metadata: None,
                         archived: false,
-                        pricing: None,
                     },
                 },)))
                 .unwrap(),
@@ -378,7 +371,6 @@ fn test_mint_multiple_exceeds_limit() {
             transfer_agreement: None,
             metadata: None,
             archived: false,
-            pricing: None,
         },
     };
 
@@ -1126,7 +1118,6 @@ fn mint(deps: DepsMut, token_id: impl Into<String>) -> Result<Response, Contract
             transfer_agreement: None,
             metadata: None,
             archived: false,
-            pricing: None,
         },
     }]);
     execute(deps, mock_env(), mock_info("owner", &[]), msg)

--- a/contracts/andromeda_cw721/schema/execute_msg.json
+++ b/contracts/andromeda_cw721/schema/execute_msg.json
@@ -764,17 +764,6 @@
           "description": "The name of the token",
           "type": "string"
         },
-        "pricing": {
-          "description": "The current price listing for the token",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Coin"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "publisher": {
           "description": "The original publisher of the token (immutable)",
           "type": "string"

--- a/contracts/andromeda_cw721/src/contract.rs
+++ b/contracts/andromeda_cw721/src/contract.rs
@@ -188,7 +188,6 @@ fn execute_transfer(
     token.owner = deps.api.addr_validate(&recipient)?;
     token.approvals.clear();
     token.extension.transfer_agreement = None;
-    token.extension.pricing = None;
     contract.tokens.save(deps.storage, &token_id, &token)?;
     Ok(resp
         .add_attribute("action", "transfer")

--- a/contracts/andromeda_cw721/src/testing/mod.rs
+++ b/contracts/andromeda_cw721/src/testing/mod.rs
@@ -207,7 +207,6 @@ fn test_transfer_nft() {
             transfer_agreement: None,
             metadata: None,
             archived: false,
-            pricing: None,
         },
     );
 
@@ -275,7 +274,6 @@ fn test_agreed_transfer_nft() {
             }),
             metadata: None,
             archived: false,
-            pricing: None,
         },
     );
 
@@ -335,7 +333,6 @@ fn test_agreed_transfer_nft_wildcard() {
             }),
             metadata: None,
             archived: false,
-            pricing: None,
         },
     );
 
@@ -375,7 +372,6 @@ fn test_archive() {
             transfer_agreement: None,
             metadata: None,
             archived: false,
-            pricing: None,
         },
     );
 
@@ -417,7 +413,6 @@ fn test_burn() {
             transfer_agreement: None,
             metadata: None,
             archived: false,
-            pricing: None,
         },
     );
 
@@ -474,7 +469,6 @@ fn test_archived_check() {
             transfer_agreement: None,
             metadata: None,
             archived: true,
-            pricing: None,
         },
     );
 
@@ -513,7 +507,6 @@ fn test_transfer_agreement() {
             transfer_agreement: None,
             metadata: None,
             archived: false,
-            pricing: None,
         },
     );
 
@@ -588,7 +581,6 @@ fn test_modules() {
             transfer_agreement: None,
             metadata: None,
             archived: false,
-            pricing: None,
         },
     );
 
@@ -704,7 +696,6 @@ fn test_transfer_with_offer() {
             transfer_agreement: None,
             metadata: None,
             archived: false,
-            pricing: None,
         },
     );
 

--- a/contracts/andromeda_wrapped_cw721/src/contract.rs
+++ b/contracts/andromeda_wrapped_cw721/src/contract.rs
@@ -156,7 +156,6 @@ fn execute_wrap(
             ]),
         }),
         archived: false,
-        pricing: None,
     };
     let mint_msg = MintMsg {
         token_id: wrapped_token_id.to_string(),
@@ -410,7 +409,6 @@ mod tests {
                 ]),
             }),
             archived: false,
-            pricing: None,
         };
         let mint_msg = MintMsg {
             token_id: token_id.clone(),
@@ -483,7 +481,6 @@ mod tests {
                 ]),
             }),
             archived: false,
-            pricing: None,
         };
         let mint_msg = MintMsg {
             token_id: wrapped_token_id.to_owned(),

--- a/packages/andromeda_protocol/src/cw721.rs
+++ b/packages/andromeda_protocol/src/cw721.rs
@@ -111,8 +111,6 @@ pub struct TokenExtension {
     pub metadata: Option<TokenMetadata>,
     /// Whether the token is archived or not
     pub archived: bool,
-    /// The current price listing for the token
-    pub pricing: Option<Coin>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/andromeda_protocol/src/testing/mock_querier.rs
+++ b/packages/andromeda_protocol/src/testing/mock_querier.rs
@@ -350,7 +350,6 @@ impl WasmMockQuerier {
                             ]),
                         }),
                         archived: false,
-                        pricing: None,
                     }
                 } else {
                     TokenExtension {
@@ -360,7 +359,6 @@ impl WasmMockQuerier {
                         transfer_agreement,
                         metadata: None,
                         archived: false,
-                        pricing: None,
                     }
                 };
                 let response = NftInfoResponse {


### PR DESCRIPTION
# Motivation
Way back in this change https://github.com/andromedaprotocol/andromeda-contracts/pull/106 we made the `pricing` field obsolete by instead using a wildcard transfer agreement. Here is the relevant part from that PR:

> Along with the above changes, I removed the UpdatePricing message for our cw721 and replaced it with a wildcard transfer agreement. That means that if a user wants to sell the nft to anyone for a given price, they can set the purchaser of the transfer agreement as *. This further reduces the size of the cw721 contract.

At this time the `pricing` field was not remained, probably just an oversight at the time. 

# Implementation
Simply just removed the field and updated the tests that referenced it.

I also ran `build_schema.sh` to get our schema up to date. 

# Testing

## Unit/Integration tests
None necessary. 

## On-chain tests
None necessary. 

# Future work
None.