### PR TITLE
CU-28n5cn4 | Fix conflict between Mission and AddressList

### DIFF
--- a/contracts/andromeda_crowdfund/src/contract.rs
+++ b/contracts/andromeda_crowdfund/src/contract.rs
@@ -9,7 +9,10 @@ use andromeda_protocol::{
     rates::get_tax_amount,
 };
 use common::{
-    ado_base::{recipient::Recipient, InstantiateMsg as BaseInstantiateMsg},
+    ado_base::{
+        hooks::AndromedaHook, recipient::Recipient, AndromedaMsg,
+        InstantiateMsg as BaseInstantiateMsg,
+    },
     deduct_funds, encode_binary,
     error::ContractError,
     merge_sub_msgs, require, Funds,
@@ -75,10 +78,26 @@ pub fn execute(
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
+    let contract = ADOContract::default();
+
+    // Do this before the hooks get fired off to ensure that there is no conflict with the mission
+    // contract not being whitelisted.
+    if let ExecuteMsg::AndrReceive(AndromedaMsg::UpdateMissionContract { address }) = msg {
+        return contract.execute_update_mission_contract(deps, info, address);
+    };
+
+    contract.module_hook::<Response>(
+        deps.storage,
+        deps.api,
+        deps.querier,
+        AndromedaHook::OnExecute {
+            sender: info.sender.to_string(),
+            payload: encode_binary(&msg)?,
+        },
+    )?;
+
     match msg {
-        ExecuteMsg::AndrReceive(msg) => {
-            ADOContract::default().execute(deps, env, info, msg, execute)
-        }
+        ExecuteMsg::AndrReceive(msg) => contract.execute(deps, env, info, msg, execute),
         ExecuteMsg::Mint(mint_msgs) => execute_mint(deps, env, info, mint_msgs),
         ExecuteMsg::StartSale {
             expiration,

--- a/contracts/andromeda_crowdfund/src/testing/mock_querier.rs
+++ b/contracts/andromeda_crowdfund/src/testing/mock_querier.rs
@@ -6,13 +6,14 @@ use cosmwasm_std::{
     from_binary, from_slice,
     testing::{mock_env, MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR},
     to_binary, BankMsg, Binary, Coin, ContractResult, CosmosMsg, OwnedDeps, Querier, QuerierResult,
-    QueryRequest, SubMsg, SystemError, SystemResult, Uint128, WasmQuery,
+    QueryRequest, Response, SubMsg, SystemError, SystemResult, Uint128, WasmQuery,
 };
 use cw721::{Cw721QueryMsg, TokensResponse};
 use terra_cosmwasm::TerraQueryWrapper;
 
 pub const MOCK_TOKEN_CONTRACT: &str = "token_contract";
 pub const MOCK_RATES_CONTRACT: &str = "rates_contract";
+pub const MOCK_ADDRESSLIST_CONTRACT: &str = "addresslist_contract";
 
 pub const MOCK_TAX_RECIPIENT: &str = "tax_recipient";
 pub const MOCK_ROYALTY_RECIPIENT: &str = "royalty_recipient";
@@ -65,6 +66,7 @@ impl WasmMockQuerier {
                 match contract_addr.as_str() {
                     MOCK_TOKEN_CONTRACT => self.handle_token_query(msg),
                     MOCK_RATES_CONTRACT => self.handle_rates_query(msg),
+                    MOCK_ADDRESSLIST_CONTRACT => self.handle_addresslist_query(msg),
                     _ => panic!("Unknown Contract Address {}", contract_addr),
                 }
             }
@@ -149,6 +151,23 @@ impl WasmMockQuerier {
                         leftover_funds: new_funds,
                     };
                     SystemResult::Ok(ContractResult::Ok(to_binary(&response).unwrap()))
+                }
+                _ => SystemResult::Ok(ContractResult::Err("UnsupportedOperation".to_string())),
+            },
+        }
+    }
+
+    fn handle_addresslist_query(&self, msg: &Binary) -> QuerierResult {
+        match from_binary(msg).unwrap() {
+            HookMsg::AndrHook(hook_msg) => match hook_msg {
+                AndromedaHook::OnExecute { sender, payload: _ } => {
+                    let whitelisted_addresses = ["sender"];
+                    let response: Response = Response::default();
+                    if whitelisted_addresses.contains(&sender.as_str()) {
+                        SystemResult::Ok(ContractResult::Ok(to_binary(&response).unwrap()))
+                    } else {
+                        SystemResult::Ok(ContractResult::Err("InvalidAddress".to_string()))
+                    }
                 }
                 _ => SystemResult::Ok(ContractResult::Err("UnsupportedOperation".to_string())),
             },

--- a/contracts/andromeda_crowdfund/src/testing/tests.rs
+++ b/contracts/andromeda_crowdfund/src/testing/tests.rs
@@ -2,9 +2,9 @@ use crate::{
     contract::{execute, instantiate, query, MAX_MINT_LIMIT},
     state::{Config, Purchase, State, AVAILABLE_TOKENS, CONFIG, PURCHASES, SALE_CONDUCTED, STATE},
     testing::mock_querier::{
-        mock_dependencies_custom, MOCK_CONDITIONS_MET_CONTRACT, MOCK_CONDITIONS_NOT_MET_CONTRACT,
-        MOCK_RATES_CONTRACT, MOCK_ROYALTY_RECIPIENT, MOCK_TAX_RECIPIENT, MOCK_TOKENS_FOR_SALE,
-        MOCK_TOKEN_CONTRACT,
+        mock_dependencies_custom, MOCK_ADDRESSLIST_CONTRACT, MOCK_CONDITIONS_MET_CONTRACT,
+        MOCK_CONDITIONS_NOT_MET_CONTRACT, MOCK_RATES_CONTRACT, MOCK_ROYALTY_RECIPIENT,
+        MOCK_TAX_RECIPIENT, MOCK_TOKENS_FOR_SALE, MOCK_TOKEN_CONTRACT,
     },
 };
 use andromeda_protocol::{
@@ -13,8 +13,9 @@ use andromeda_protocol::{
 };
 use common::{
     ado_base::{
-        modules::{Module, RATES},
+        modules::{Module, ADDRESS_LIST, RATES},
         recipient::Recipient,
+        AndromedaMsg,
     },
     encode_binary,
     error::ContractError,
@@ -23,7 +24,7 @@ use common::{
 use cosmwasm_std::{
     coin, coins, from_binary,
     testing::{mock_env, mock_info},
-    Addr, BankMsg, Coin, CosmosMsg, DepsMut, Response, SubMsg, Uint128, WasmMsg,
+    Addr, BankMsg, Coin, CosmosMsg, DepsMut, Response, StdError, SubMsg, Uint128, WasmMsg,
 };
 use cw0::Expiration;
 
@@ -1587,4 +1588,53 @@ fn test_end_sale_limit_zero() {
     let res = execute(deps.as_mut(), mock_env(), info, msg);
 
     assert_eq!(ContractError::LimitMustNotBeZero {}, res.unwrap_err());
+}
+
+#[test]
+fn test_addresslist() {
+    let mut deps = mock_dependencies_custom(&[]);
+    let modules = vec![Module {
+        module_type: ADDRESS_LIST.to_owned(),
+        address: AndrAddress {
+            identifier: MOCK_ADDRESSLIST_CONTRACT.to_owned(),
+        },
+        is_mutable: false,
+    }];
+    let msg = InstantiateMsg {
+        token_address: AndrAddress {
+            identifier: MOCK_TOKEN_CONTRACT.to_owned(),
+        },
+        modules: Some(modules),
+        can_mint_after_sale: true,
+    };
+
+    let info = mock_info("mission_contract", &[]);
+    let _res = instantiate(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
+
+    // Update mission contract
+    let msg = ExecuteMsg::AndrReceive(AndromedaMsg::UpdateMissionContract {
+        address: "mission_contract".to_string(),
+    });
+
+    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+    assert_eq!(
+        Response::new()
+            .add_attribute("action", "update_mission_contract")
+            .add_attribute("address", "mission_contract"),
+        res
+    );
+
+    // Not whitelisted user
+    let msg = ExecuteMsg::Purchase {
+        number_of_tokens: None,
+    };
+    let info = mock_info("not_whitelisted", &[]);
+    let res = execute(deps.as_mut(), mock_env(), info, msg);
+
+    assert_eq!(
+        ContractError::Std(StdError::generic_err(
+            "Querier contract error: InvalidAddress"
+        )),
+        res.unwrap_err()
+    );
 }

--- a/contracts/andromeda_cw20/src/contract.rs
+++ b/contracts/andromeda_cw20/src/contract.rs
@@ -8,7 +8,7 @@ use cosmwasm_std::{
 use ado_base::ADOContract;
 use andromeda_protocol::cw20::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use common::{
-    ado_base::{hooks::AndromedaHook, InstantiateMsg as BaseInstantiateMsg},
+    ado_base::{hooks::AndromedaHook, AndromedaMsg, InstantiateMsg as BaseInstantiateMsg},
     error::ContractError,
     Funds,
 };
@@ -58,6 +58,13 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     let contract = ADOContract::default();
+
+    // Do this before the hooks get fired off to ensure that there is no conflict with the mission
+    // contract not being whitelisted.
+    if let ExecuteMsg::AndrReceive(AndromedaMsg::UpdateMissionContract { address }) = msg {
+        return contract.execute_update_mission_contract(deps, info, address);
+    };
+
     contract.module_hook::<Response>(
         deps.storage,
         deps.api,

--- a/contracts/andromeda_cw20/src/testing/tests.rs
+++ b/contracts/andromeda_cw20/src/testing/tests.rs
@@ -10,7 +10,7 @@ use andromeda_protocol::{
 use common::{
     ado_base::{
         modules::{Module, ADDRESS_LIST, RATES, RECEIPT},
-        AndromedaQuery,
+        AndromedaMsg, AndromedaQuery,
     },
     error::ContractError,
     mission::AndrAddress,
@@ -426,5 +426,47 @@ fn test_send() {
         BALANCES
             .load(deps.as_ref().storage, &Addr::unchecked("rates_recipient"))
             .unwrap()
+    );
+}
+
+#[test]
+fn test_update_mission_contract() {
+    let mut deps = mock_dependencies_custom(&[]);
+
+    let modules: Vec<Module> = vec![Module {
+        module_type: ADDRESS_LIST.to_owned(),
+        address: AndrAddress {
+            identifier: MOCK_ADDRESSLIST_CONTRACT.to_owned(),
+        },
+        is_mutable: false,
+    }];
+
+    let info = mock_info("mission_contract", &[]);
+    let instantiate_msg = InstantiateMsg {
+        name: "Name".into(),
+        symbol: "Symbol".into(),
+        decimals: 6,
+        initial_balances: vec![Cw20Coin {
+            amount: 1000u128.into(),
+            address: "sender".to_string(),
+        }],
+        mint: None,
+        marketing: None,
+        modules: Some(modules),
+    };
+
+    let _res = instantiate(deps.as_mut(), mock_env(), info.clone(), instantiate_msg).unwrap();
+
+    let msg = ExecuteMsg::AndrReceive(AndromedaMsg::UpdateMissionContract {
+        address: "mission_contract".to_string(),
+    });
+
+    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    assert_eq!(
+        Response::new()
+            .add_attribute("action", "update_mission_contract")
+            .add_attribute("address", "mission_contract"),
+        res
     );
 }

--- a/contracts/andromeda_cw721/src/contract.rs
+++ b/contracts/andromeda_cw721/src/contract.rs
@@ -14,7 +14,7 @@ use andromeda_protocol::{
 use common::{
     ado_base::{
         hooks::{AndromedaHook, OnFundsTransferResponse},
-        InstantiateMsg as BaseInstantiateMsg,
+        AndromedaMsg, InstantiateMsg as BaseInstantiateMsg,
     },
     encode_binary,
     error::ContractError,
@@ -65,6 +65,12 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     let contract = ADOContract::default();
+
+    // Do this before the hooks get fired off to ensure that there is no conflict with the mission
+    // contract not being whitelisted.
+    if let ExecuteMsg::AndrReceive(AndromedaMsg::UpdateMissionContract { address }) = msg {
+        return contract.execute_update_mission_contract(deps, info, address);
+    };
 
     contract.module_hook::<Response>(
         deps.storage,

--- a/contracts/andromeda_cw721/src/testing/mod.rs
+++ b/contracts/andromeda_cw721/src/testing/mod.rs
@@ -9,7 +9,7 @@ use common::{
     ado_base::{
         hooks::{AndromedaHook, OnFundsTransferResponse},
         modules::{Module, ADDRESS_LIST, OFFERS, RATES, RECEIPT},
-        AndromedaQuery,
+        AndromedaMsg, AndromedaQuery,
     },
     error::ContractError,
     mission::AndrAddress,
@@ -719,6 +719,44 @@ fn test_transfer_with_offer() {
             .add_submessage(msg)
             .add_attribute("action", "transfer")
             .add_attribute("recipient", "purchaser"),
+        res
+    );
+}
+
+#[test]
+fn test_update_mission_contract() {
+    let mut deps = mock_dependencies_custom(&[]);
+
+    let modules: Vec<Module> = vec![Module {
+        module_type: ADDRESS_LIST.to_owned(),
+        address: AndrAddress {
+            identifier: MOCK_ADDRESSLIST_CONTRACT.to_owned(),
+        },
+        is_mutable: false,
+    }];
+
+    let info = mock_info("mission_contract", &[]);
+    let inst_msg = InstantiateMsg {
+        name: NAME.to_string(),
+        symbol: SYMBOL.to_string(),
+        minter: AndrAddress {
+            identifier: MINTER.to_string(),
+        },
+        modules: Some(modules),
+    };
+
+    let _res = instantiate(deps.as_mut(), mock_env(), info.clone(), inst_msg).unwrap();
+
+    let msg = ExecuteMsg::AndrReceive(AndromedaMsg::UpdateMissionContract {
+        address: "mission_contract".to_string(),
+    });
+
+    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    assert_eq!(
+        Response::new()
+            .add_attribute("action", "update_mission_contract")
+            .add_attribute("address", "mission_contract"),
         res
     );
 }

--- a/contracts/andromeda_splitter/src/contract.rs
+++ b/contracts/andromeda_splitter/src/contract.rs
@@ -55,7 +55,15 @@ pub fn execute(
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
-    ADOContract::default().module_hook::<Response>(
+    let contract = ADOContract::default();
+
+    // Do this before the hooks get fired off to ensure that there is no conflict with the mission
+    // contract not being whitelisted.
+    if let ExecuteMsg::AndrReceive(AndromedaMsg::UpdateMissionContract { address }) = msg {
+        return contract.execute_update_mission_contract(deps, info, address);
+    };
+
+    contract.module_hook::<Response>(
         deps.storage,
         deps.api,
         deps.querier,

--- a/contracts/andromeda_splitter/src/testing/tests.rs
+++ b/contracts/andromeda_splitter/src/testing/tests.rs
@@ -10,7 +10,8 @@ use andromeda_protocol::{
     testing::mock_querier::{mock_dependencies_custom, MOCK_ADDRESSLIST_CONTRACT},
 };
 use common::{
-    ado_base::modules::Module, ado_base::recipient::Recipient, error::ContractError,
+    ado_base::{modules::Module, recipient::Recipient, AndromedaMsg},
+    error::ContractError,
     mission::AndrAddress,
 };
 
@@ -63,6 +64,43 @@ fn test_modules() {
             })
             .add_attribute("action", "send")
             .add_attribute("sender", "sender"),
+        res
+    );
+}
+
+#[test]
+fn test_update_mission_contract() {
+    let mut deps = mock_dependencies_custom(&[]);
+
+    let modules: Vec<Module> = vec![Module {
+        module_type: "address_list".to_string(),
+        address: AndrAddress {
+            identifier: MOCK_ADDRESSLIST_CONTRACT.to_owned(),
+        },
+        is_mutable: false,
+    }];
+
+    let info = mock_info("mission_contract", &[]);
+    let msg = InstantiateMsg {
+        modules: Some(modules),
+        recipients: vec![AddressPercent {
+            recipient: Recipient::from_string(String::from("Some Address")),
+            percent: Decimal::percent(100),
+        }],
+    };
+
+    let _res = instantiate(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
+
+    let msg = ExecuteMsg::AndrReceive(AndromedaMsg::UpdateMissionContract {
+        address: "mission_contract".to_string(),
+    });
+
+    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    assert_eq!(
+        Response::new()
+            .add_attribute("action", "update_mission_contract")
+            .add_attribute("address", "mission_contract"),
         res
     );
 }

--- a/contracts/andromeda_timelock/src/contract.rs
+++ b/contracts/andromeda_timelock/src/contract.rs
@@ -7,7 +7,10 @@ use andromeda_protocol::timelock::{
     GetLockedFundsResponse, InstantiateMsg, MigrateMsg, QueryMsg,
 };
 use common::{
-    ado_base::{hooks::AndromedaHook, recipient::Recipient, InstantiateMsg as BaseInstantiateMsg},
+    ado_base::{
+        hooks::AndromedaHook, recipient::Recipient, AndromedaMsg,
+        InstantiateMsg as BaseInstantiateMsg,
+    },
     encode_binary,
     error::ContractError,
     require,
@@ -47,7 +50,15 @@ pub fn execute(
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
-    ADOContract::default().module_hook::<Response>(
+    let contract = ADOContract::default();
+
+    // Do this before the hooks get fired off to ensure that there is no conflict with the mission
+    // contract not being whitelisted.
+    if let ExecuteMsg::AndrReceive(AndromedaMsg::UpdateMissionContract { address }) = msg {
+        return contract.execute_update_mission_contract(deps, info, address);
+    };
+
+    contract.module_hook::<Response>(
         deps.storage,
         deps.api,
         deps.querier,

--- a/contracts/andromeda_timelock/src/testing/tests.rs
+++ b/contracts/andromeda_timelock/src/testing/tests.rs
@@ -9,7 +9,11 @@ use andromeda_protocol::{
     testing::mock_querier::{mock_dependencies_custom, MOCK_ADDRESSLIST_CONTRACT},
     timelock::{ExecuteMsg, InstantiateMsg},
 };
-use common::{ado_base::modules::Module, error::ContractError, mission::AndrAddress};
+use common::{
+    ado_base::{modules::Module, AndromedaMsg},
+    error::ContractError,
+    mission::AndrAddress,
+};
 
 #[test]
 fn test_modules() {
@@ -58,6 +62,38 @@ fn test_modules() {
             .add_attribute("sender", "sender")
             .add_attribute("recipient", "Addr(\"sender\")")
             .add_attribute("condition", "None"),
+        res
+    );
+}
+
+#[test]
+fn test_update_mission_contract() {
+    let mut deps = mock_dependencies_custom(&[]);
+
+    let modules: Vec<Module> = vec![Module {
+        module_type: "address_list".to_string(),
+        address: AndrAddress {
+            identifier: MOCK_ADDRESSLIST_CONTRACT.to_owned(),
+        },
+        is_mutable: false,
+    }];
+
+    let info = mock_info("mission_contract", &[]);
+    let msg = InstantiateMsg {
+        modules: Some(modules),
+    };
+    let _res = instantiate(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
+
+    let msg = ExecuteMsg::AndrReceive(AndromedaMsg::UpdateMissionContract {
+        address: "mission_contract".to_string(),
+    });
+
+    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    assert_eq!(
+        Response::new()
+            .add_attribute("action", "update_mission_contract")
+            .add_attribute("address", "mission_contract"),
         res
     );
 }


### PR DESCRIPTION
# Motivation
When an ADO has an addresslist module, the mission cannot assign itself as it is not on the addresslist (if it is a whitelist). This is because we check the addresslist on any `execute` operation, which includes updating the mission contract.

# Implementation
I decided to handle the update mission message before the hooks are fired with a conditional. Another possible approach that I considered was assigning the instantiator of the AddressList to the addresslist. I decided against this as there are cases where we don't necessarily want the owner to be whitelisted, such as when an external KYC service manages the whitelist. 

I added this conditional check for cw20, cw721, timelock, splitter, and crowdfund. 

# Testing

## Unit/Integration tests
For each contract that I modified I added a unit test ensuring that the mission contract could assign itself. 

## On-chain tests
None here, it will be easier to test as part of the test suite we have for full missions. 

# Future work
n/a