### PR TITLE
CU-27rtkkr | Validate andr address

### DIFF
--- a/contracts/andromeda_crowdfund/src/contract.rs
+++ b/contracts/andromeda_crowdfund/src/contract.rs
@@ -115,13 +115,7 @@ fn execute_andr_receive(
     match msg {
         AndromedaMsg::ValidateAndrAddresses {} => {
             let config = CONFIG.load(deps.storage)?;
-            contract.validate_andr_addresses(
-                deps.as_ref(),
-                env,
-                info,
-                vec![&config.token_address],
-            )?;
-            Ok(Response::new())
+            contract.validate_andr_addresses(deps.as_ref(), env, info, vec![&config.token_address])
         }
         _ => contract.execute(deps, env, info, msg, execute),
     }

--- a/contracts/andromeda_crowdfund/src/testing/mock_querier.rs
+++ b/contracts/andromeda_crowdfund/src/testing/mock_querier.rs
@@ -1,3 +1,4 @@
+use andromeda_protocol::mission::QueryMsg as MissionQueryMsg;
 use common::{
     ado_base::hooks::{AndromedaHook, HookMsg, OnFundsTransferResponse},
     Funds,
@@ -13,6 +14,7 @@ use terra_cosmwasm::TerraQueryWrapper;
 
 pub const MOCK_TOKEN_CONTRACT: &str = "token_contract";
 pub const MOCK_RATES_CONTRACT: &str = "rates_contract";
+pub const MOCK_MISSION_CONTRACT: &str = "mission_contract";
 
 pub const MOCK_TAX_RECIPIENT: &str = "tax_recipient";
 pub const MOCK_ROYALTY_RECIPIENT: &str = "royalty_recipient";
@@ -65,10 +67,21 @@ impl WasmMockQuerier {
                 match contract_addr.as_str() {
                     MOCK_TOKEN_CONTRACT => self.handle_token_query(msg),
                     MOCK_RATES_CONTRACT => self.handle_rates_query(msg),
+                    MOCK_MISSION_CONTRACT => self.handle_mission_query(msg),
                     _ => panic!("Unknown Contract Address {}", contract_addr),
                 }
             }
             _ => self.base.handle_query(request),
+        }
+    }
+
+    fn handle_mission_query(&self, msg: &Binary) -> QuerierResult {
+        match from_binary(msg).unwrap() {
+            MissionQueryMsg::ComponentExists { name } => {
+                let value = name == "existing_component";
+                SystemResult::Ok(ContractResult::Ok(to_binary(&value).unwrap()))
+            }
+            _ => panic!("Unsupported Query"),
         }
     }
 

--- a/contracts/andromeda_crowdfund/src/testing/mock_querier.rs
+++ b/contracts/andromeda_crowdfund/src/testing/mock_querier.rs
@@ -78,7 +78,7 @@ impl WasmMockQuerier {
     fn handle_mission_query(&self, msg: &Binary) -> QuerierResult {
         match from_binary(msg).unwrap() {
             MissionQueryMsg::ComponentExists { name } => {
-                let value = name == "existing_component";
+                let value = name == "e";
                 SystemResult::Ok(ContractResult::Ok(to_binary(&value).unwrap()))
             }
             _ => panic!("Unsupported Query"),

--- a/contracts/andromeda_crowdfund/src/testing/tests.rs
+++ b/contracts/andromeda_crowdfund/src/testing/tests.rs
@@ -1596,7 +1596,7 @@ fn test_validate_andr_addresses_existing() {
     let mut deps = mock_dependencies_custom(&[]);
     let msg = InstantiateMsg {
         token_address: AndrAddress {
-            identifier: "existing_component".to_owned(),
+            identifier: "e".to_owned(),
         },
         modules: None,
         can_mint_after_sale: true,
@@ -1627,7 +1627,7 @@ fn test_validate_andr_addresses_nonexisting() {
     let mut deps = mock_dependencies_custom(&[]);
     let msg = InstantiateMsg {
         token_address: AndrAddress {
-            identifier: "nonexisting_component".to_owned(),
+            identifier: "b".to_owned(),
         },
         modules: None,
         can_mint_after_sale: true,
@@ -1652,7 +1652,7 @@ fn test_validate_andr_addresses_nonexisting() {
 
     assert_eq!(
         ContractError::InvalidComponent {
-            name: "nonexisting_component".to_string()
+            name: "b".to_string()
         },
         res.unwrap_err()
     );

--- a/contracts/andromeda_crowdfund/src/testing/tests.rs
+++ b/contracts/andromeda_crowdfund/src/testing/tests.rs
@@ -1657,3 +1657,34 @@ fn test_validate_andr_addresses_nonexisting() {
         res.unwrap_err()
     );
 }
+
+#[test]
+fn test_validate_andr_addresses_regular_address() {
+    let mut deps = mock_dependencies_custom(&[]);
+    let msg = InstantiateMsg {
+        token_address: AndrAddress {
+            identifier: "terra1asdf1ssdfadf".to_owned(),
+        },
+        modules: None,
+        can_mint_after_sale: true,
+    };
+
+    let info = mock_info("owner", &[]);
+    let _res = instantiate(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();
+
+    ADOContract::default()
+        .execute_update_mission_contract(
+            deps.as_mut(),
+            mock_env(),
+            info,
+            MOCK_MISSION_CONTRACT.to_owned(),
+        )
+        .unwrap();
+
+    let msg = ExecuteMsg::AndrReceive(AndromedaMsg::ValidateAndrAddresses {});
+    let info = mock_info(mock_env().contract.address.as_str(), &[]);
+
+    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    assert_eq!(Response::new(), res);
+}

--- a/contracts/andromeda_cw721/src/contract.rs
+++ b/contracts/andromeda_cw721/src/contract.rs
@@ -107,15 +107,7 @@ fn execute_andr_receive(
     match msg {
         AndromedaMsg::ValidateAndrAddresses {} => {
             let andr_minter = ANDR_MINTER.load(deps.storage)?;
-            let true_addresses =
-                contract.validate_andr_addresses(deps.as_ref(), env, info, vec![&andr_minter])?;
-
-            let cw721_contract = AndrCW721Contract::default();
-            // Only allow minter to be set once to maintain immutability.
-            if cw721_contract.minter.may_load(deps.storage)?.is_none() {
-                save_minter(&cw721_contract, deps.storage, &true_addresses[0])?;
-            }
-            Ok(Response::new())
+            contract.validate_andr_addresses(deps.as_ref(), env, info, vec![&andr_minter])
         }
         _ => contract.execute(deps, env, info, msg, execute),
     }

--- a/contracts/andromeda_cw721/src/testing/mod.rs
+++ b/contracts/andromeda_cw721/src/testing/mod.rs
@@ -731,7 +731,7 @@ fn test_validate_andr_addresses_existing() {
         symbol: SYMBOL.to_owned(),
         name: NAME.to_owned(),
         minter: AndrAddress {
-            identifier: "existing_component".to_owned(),
+            identifier: "e".to_owned(),
         },
         modules: None,
     };
@@ -763,7 +763,7 @@ fn test_validate_andr_addresses_nonexisting() {
         symbol: SYMBOL.to_owned(),
         name: NAME.to_owned(),
         minter: AndrAddress {
-            identifier: "nonexisting_component".to_owned(),
+            identifier: "b".to_owned(),
         },
         modules: None,
     };
@@ -787,7 +787,7 @@ fn test_validate_andr_addresses_nonexisting() {
 
     assert_eq!(
         ContractError::InvalidComponent {
-            name: "nonexisting_component".to_string()
+            name: "b".to_string()
         },
         res.unwrap_err()
     );

--- a/contracts/andromeda_mission/src/contract.rs
+++ b/contracts/andromeda_mission/src/contract.rs
@@ -246,6 +246,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
         QueryMsg::GetAddresses {} => encode_binary(&query_component_addresses(deps)?),
         QueryMsg::GetComponents {} => encode_binary(&query_component_descriptors(deps)?),
         QueryMsg::Config {} => encode_binary(&query_config(deps)?),
+        QueryMsg::ComponentExists { name } => encode_binary(&query_component_exists(deps, name)),
     }
 }
 
@@ -277,6 +278,10 @@ fn query_component_address(deps: Deps, name: String) -> Result<String, ContractE
 fn query_component_descriptors(deps: Deps) -> Result<Vec<MissionComponent>, ContractError> {
     let value = load_component_descriptors(deps.storage)?;
     Ok(value)
+}
+
+fn query_component_exists(deps: Deps, name: String) -> bool {
+    ADO_DESCRIPTORS.has(deps.storage, &name)
 }
 
 fn query_component_addresses(deps: Deps) -> Result<Vec<ComponentAddress>, ContractError> {

--- a/contracts/andromeda_mission/src/contract.rs
+++ b/contracts/andromeda_mission/src/contract.rs
@@ -18,8 +18,8 @@ use common::{
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo, QuerierWrapper, Reply, ReplyOn, Response,
-    StdError, Storage, SubMsg, WasmMsg,
+    Addr, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo, QuerierWrapper, Reply, ReplyOn,
+    Response, StdError, Storage, SubMsg, WasmMsg,
 };
 use cw2::{get_contract_version, set_contract_version};
 
@@ -124,6 +124,9 @@ fn execute_add_mission_component(
 
     let current_addr = ADO_ADDRESSES.may_load(storage, &component.name)?;
     require(current_addr.is_none(), ContractError::NameAlreadyTaken {})?;
+
+    // This is a default value that will be overridden on `reply`.
+    ADO_ADDRESSES.save(storage, &component.name, &Addr::unchecked(""))?;
 
     let idx = add_mission_component(storage, &component)?;
     let inst_msg = contract.generate_instantiate_msg(
@@ -281,7 +284,7 @@ fn query_component_descriptors(deps: Deps) -> Result<Vec<MissionComponent>, Cont
 }
 
 fn query_component_exists(deps: Deps, name: String) -> bool {
-    ADO_DESCRIPTORS.has(deps.storage, &name)
+    ADO_ADDRESSES.has(deps.storage, &name)
 }
 
 fn query_component_addresses(deps: Deps) -> Result<Vec<ComponentAddress>, ContractError> {

--- a/contracts/andromeda_mission/src/testing/mod.rs
+++ b/contracts/andromeda_mission/src/testing/mod.rs
@@ -70,7 +70,39 @@ fn test_instantiation() {
             attr("andr_mission", "Some Mission"),
         ]);
 
-    assert_eq!(expected, res)
+    assert_eq!(expected, res);
+
+    assert_eq!(
+        Addr::unchecked(""),
+        ADO_ADDRESSES.load(deps.as_ref().storage, "token").unwrap()
+    );
+}
+
+#[test]
+fn test_instantiation_duplicate_components() {
+    let mut deps = mock_dependencies_custom(&[]);
+
+    let msg = InstantiateMsg {
+        operators: vec![],
+        mission: vec![
+            MissionComponent {
+                name: "component".to_string(),
+                ado_type: "cw721".to_string(),
+                instantiate_msg: to_binary(&true).unwrap(),
+            },
+            MissionComponent {
+                name: "component".to_string(),
+                ado_type: "cw20".to_string(),
+                instantiate_msg: to_binary(&true).unwrap(),
+            },
+        ],
+        name: String::from("Some Mission"),
+        primitive_contract: String::from("primitive_contract"),
+    };
+    let info = mock_info("creator", &[]);
+
+    let res = instantiate(deps.as_mut(), mock_env(), info, msg);
+    assert_eq!(ContractError::NameAlreadyTaken {}, res.unwrap_err());
 }
 
 #[test]
@@ -181,7 +213,12 @@ fn test_add_mission_component() {
             attr("type", "cw721"),
         ]);
 
-    assert_eq!(expected, res)
+    assert_eq!(expected, res);
+
+    assert_eq!(
+        Addr::unchecked(""),
+        ADO_ADDRESSES.load(deps.as_ref().storage, "token").unwrap()
+    );
 }
 
 #[test]
@@ -612,5 +649,10 @@ fn test_reply_assign_mission() {
     };
     let expected = Response::new().add_submessage(exec_submsg);
 
-    assert_eq!(expected, res)
+    assert_eq!(expected, res);
+
+    assert_eq!(
+        Addr::unchecked("tokenaddress"),
+        ADO_ADDRESSES.load(deps.as_ref().storage, "token").unwrap()
+    );
 }

--- a/packages/ado_base/src/execute.rs
+++ b/packages/ado_base/src/execute.rs
@@ -65,8 +65,7 @@ impl<'a> ADOContract<'a> {
                 self.execute_update_mission_contract(deps, env, info, address)
             }
             AndromedaMsg::ValidateAndrAddresses {} => {
-                self.validate_andr_addresses(deps.as_ref(), env, info, vec![])?;
-                Ok(Response::new())
+                self.validate_andr_addresses(deps.as_ref(), env, info, vec![])
             }
             #[cfg(feature = "withdraw")]
             AndromedaMsg::Withdraw {

--- a/packages/ado_base/src/lib.rs
+++ b/packages/ado_base/src/lib.rs
@@ -2,6 +2,7 @@ mod auth;
 mod execute;
 #[cfg(feature = "instantiate")]
 mod instantiate;
+pub mod mission;
 #[cfg(test)]
 mod mock_querier;
 #[cfg(feature = "modules")]

--- a/packages/ado_base/src/mission.rs
+++ b/packages/ado_base/src/mission.rs
@@ -36,7 +36,9 @@ impl<'a> ADOContract<'a> {
                     address.identifier.clone(),
                     mission_contract.clone(),
                 )?,
-                ContractError::Unauthorized {},
+                ContractError::InvalidComponent {
+                    name: address.identifier.clone(),
+                },
             )?;
         }
         Ok(Response::new())

--- a/packages/ado_base/src/mission.rs
+++ b/packages/ado_base/src/mission.rs
@@ -1,0 +1,37 @@
+use cosmwasm_std::{Addr, Deps, Env, MessageInfo, Storage};
+
+use crate::ADOContract;
+use common::{error::ContractError, mission::AndrAddress, require};
+
+impl<'a> ADOContract<'a> {
+    pub fn validate_andr_addresses(
+        &self,
+        deps: Deps,
+        env: Env,
+        info: MessageInfo,
+        addresses: Vec<&AndrAddress>,
+    ) -> Result<Vec<Addr>, ContractError> {
+        require(
+            info.sender == env.contract.address,
+            ContractError::Unauthorized {},
+        )?;
+        let mut true_addresses = vec![];
+        let mission_contract = self.get_mission_contract(deps.storage)?;
+        for address in addresses {
+            // If this errors, the identifier was invalid.
+            true_addresses.push(deps.api.addr_validate(&address.get_address(
+                deps.api,
+                &deps.querier,
+                mission_contract.clone(),
+            )?)?);
+        }
+        Ok(true_addresses)
+    }
+
+    pub fn get_mission_contract(
+        &self,
+        storage: &dyn Storage,
+    ) -> Result<Option<Addr>, ContractError> {
+        Ok(self.mission_contract.may_load(storage)?)
+    }
+}

--- a/packages/ado_base/src/mission.rs
+++ b/packages/ado_base/src/mission.rs
@@ -1,7 +1,15 @@
-use cosmwasm_std::{Addr, Deps, Env, MessageInfo, Storage};
+use cosmwasm_std::{Addr, Deps, Env, MessageInfo, QuerierWrapper, Response, Storage};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 use crate::ADOContract;
 use common::{error::ContractError, mission::AndrAddress, require};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum MissionQueryMsg {
+    ComponentExists { name: String },
+}
 
 impl<'a> ADOContract<'a> {
     pub fn validate_andr_addresses(
@@ -10,22 +18,28 @@ impl<'a> ADOContract<'a> {
         env: Env,
         info: MessageInfo,
         addresses: Vec<&AndrAddress>,
-    ) -> Result<Vec<Addr>, ContractError> {
+    ) -> Result<Response, ContractError> {
         require(
             info.sender == env.contract.address,
             ContractError::Unauthorized {},
         )?;
-        let mut true_addresses = vec![];
         let mission_contract = self.get_mission_contract(deps.storage)?;
+        require(
+            mission_contract.is_some(),
+            ContractError::MissionContractNotSpecified {},
+        )?;
+        let mission_contract = mission_contract.unwrap();
         for address in addresses {
-            // If this errors, the identifier was invalid.
-            true_addresses.push(deps.api.addr_validate(&address.get_address(
-                deps.api,
-                &deps.querier,
-                mission_contract.clone(),
-            )?)?);
+            require(
+                self.component_exists(
+                    &deps.querier,
+                    address.identifier.clone(),
+                    mission_contract.clone(),
+                )?,
+                ContractError::Unauthorized {},
+            )?;
         }
-        Ok(true_addresses)
+        Ok(Response::new())
     }
 
     pub fn get_mission_contract(
@@ -33,5 +47,15 @@ impl<'a> ADOContract<'a> {
         storage: &dyn Storage,
     ) -> Result<Option<Addr>, ContractError> {
         Ok(self.mission_contract.may_load(storage)?)
+    }
+
+    fn component_exists(
+        &self,
+        querier: &QuerierWrapper,
+        name: String,
+        mission_contract: Addr,
+    ) -> Result<bool, ContractError> {
+        Ok(querier
+            .query_wasm_smart(mission_contract, &MissionQueryMsg::ComponentExists { name })?)
     }
 }

--- a/packages/ado_base/src/mission.rs
+++ b/packages/ado_base/src/mission.rs
@@ -30,16 +30,20 @@ impl<'a> ADOContract<'a> {
         )?;
         let mission_contract = mission_contract.unwrap();
         for address in addresses {
-            require(
-                self.component_exists(
-                    &deps.querier,
-                    address.identifier.clone(),
-                    mission_contract.clone(),
-                )?,
-                ContractError::InvalidComponent {
-                    name: address.identifier.clone(),
-                },
-            )?;
+            // If the address passes this check then it doesn't refer to a mission component by
+            // name.
+            if deps.api.addr_validate(&address.identifier).is_err() {
+                require(
+                    self.component_exists(
+                        &deps.querier,
+                        address.identifier.clone(),
+                        mission_contract.clone(),
+                    )?,
+                    ContractError::InvalidComponent {
+                        name: address.identifier.clone(),
+                    },
+                )?;
+            }
         }
         Ok(Response::new())
     }

--- a/packages/ado_base/src/state.rs
+++ b/packages/ado_base/src/state.rs
@@ -46,13 +46,6 @@ impl<'a> Default for ADOContract<'a> {
 }
 
 impl<'a> ADOContract<'a> {
-    pub fn get_mission_contract(
-        &self,
-        storage: &dyn Storage,
-    ) -> Result<Option<Addr>, ContractError> {
-        Ok(self.mission_contract.may_load(storage)?)
-    }
-
     pub(crate) fn initialize_operators(
         &self,
         storage: &mut dyn Storage,

--- a/packages/andromeda_protocol/src/mission.rs
+++ b/packages/andromeda_protocol/src/mission.rs
@@ -38,6 +38,7 @@ pub enum QueryMsg {
     AndrQuery(AndromedaQuery),
     GetAddress { name: String },
     GetComponents {},
+    ComponentExists { name: String },
     GetAddresses {},
     Config {},
 }

--- a/packages/andromeda_protocol/src/testing/mock_querier.rs
+++ b/packages/andromeda_protocol/src/testing/mock_querier.rs
@@ -177,7 +177,7 @@ impl WasmMockQuerier {
     fn handle_mission_query(&self, msg: &Binary) -> QuerierResult {
         match from_binary(msg).unwrap() {
             MissionQueryMsg::ComponentExists { name } => {
-                let value = name == "existing_component";
+                let value = name == "e";
                 SystemResult::Ok(ContractResult::Ok(to_binary(&value).unwrap()))
             }
             _ => panic!("Unsupported Query"),

--- a/packages/andromeda_protocol/src/testing/mock_querier.rs
+++ b/packages/andromeda_protocol/src/testing/mock_querier.rs
@@ -16,6 +16,7 @@ use crate::{
     },
     cw721_offers::{ExecuteMsg as OffersExecuteMsg, OfferResponse, QueryMsg as OffersQueryMsg},
     factory::QueryMsg as FactoryQueryMsg,
+    mission::QueryMsg as MissionQueryMsg,
     primitive::QueryMsg as PrimitiveQueryMsg,
     rates::QueryMsg as RatesQueryMsg,
     receipt::{generate_receipt_message, QueryMsg as ReceiptQueryMsg},
@@ -42,6 +43,7 @@ pub const MOCK_CW20_CONTRACT2: &str = "cw20_contract2";
 pub const MOCK_RATES_CONTRACT: &str = "rates_contract";
 pub const MOCK_ADDRESSLIST_CONTRACT: &str = "addresslist_contract";
 pub const MOCK_RECEIPT_CONTRACT: &str = "receipt_contract";
+pub const MOCK_MISSION_CONTRACT: &str = "mission_contract";
 pub const MOCK_OFFERS_CONTRACT: &str = "offers_contract";
 
 pub const MOCK_RATES_RECIPIENT: &str = "rates_recipient";
@@ -161,6 +163,7 @@ impl WasmMockQuerier {
                     MOCK_OFFERS_CONTRACT => self.handle_offers_query(msg),
                     MOCK_RECEIPT_CONTRACT => self.handle_receipt_query(msg),
                     MOCK_FACTORY_CONTRACT => self.handle_factory_query(msg),
+                    MOCK_MISSION_CONTRACT => self.handle_mission_query(msg),
                     _ => {
                         let msg_response = IncludesAddressResponse { included: false };
                         SystemResult::Ok(ContractResult::Ok(to_binary(&msg_response).unwrap()))
@@ -168,6 +171,16 @@ impl WasmMockQuerier {
                 }
             }
             _ => self.base.handle_query(request),
+        }
+    }
+
+    fn handle_mission_query(&self, msg: &Binary) -> QuerierResult {
+        match from_binary(msg).unwrap() {
+            MissionQueryMsg::ComponentExists { name } => {
+                let value = name == "existing_component";
+                SystemResult::Ok(ContractResult::Ok(to_binary(&value).unwrap()))
+            }
+            _ => panic!("Unsupported Query"),
         }
     }
 

--- a/packages/common/src/ado_base/mod.rs
+++ b/packages/common/src/ado_base/mod.rs
@@ -35,6 +35,8 @@ pub enum AndromedaMsg {
     UpdateMissionContract {
         address: String,
     },
+    /// Called after `UpdateMissionContract` to ensure that all `AndrAddress` instances are valid.
+    ValidateAndrAddresses {},
     Withdraw {
         recipient: Option<Recipient>,
         tokens_to_withdraw: Option<Vec<Withdrawal>>,

--- a/packages/common/src/error.rs
+++ b/packages/common/src/error.rs
@@ -341,6 +341,9 @@ pub enum ContractError {
 
     #[error("Too many mint messages, limit is {limit}")]
     TooManyMintMessages { limit: u32 },
+
+    #[error("Mission contract not specified")]
+    MissionContractNotSpecified {},
 }
 
 impl From<Cw20ContractError> for ContractError {

--- a/packages/common/src/error.rs
+++ b/packages/common/src/error.rs
@@ -344,6 +344,9 @@ pub enum ContractError {
 
     #[error("Mission contract not specified")]
     MissionContractNotSpecified {},
+
+    #[error("Invalid component: {name}")]
+    InvalidComponent { name: String },
 }
 
 impl From<Cw20ContractError> for ContractError {


### PR DESCRIPTION
# Motivation
Currently there is no validation being done for `AndrAddress` as it is not possible to do in `instantiate` since the mission address hasn't been set yet. This PR adds a validation function that gets called after `UpdateMissionContract` is called by the mission. This function checks that each identifier for each `AndrAddress` is valid. 

# Implementation
I added the `ValidateAndrAddresses {}` variant to `AndromedaMsg`. This message gets broadcast after `execute_update_mission_contract` is called. The default implementation is calling the new function `validate_andr_addresses(..., addresses: Vec<&AndrAddress>)` which verifies that each address in `addresses` is a valid component.  

This function first checks that the identifier fails address validation (if not, we stop there) and then queries the mission contract to check if the component exists. To facilitate this I added a new query to mission `ComponentExists {name}` which checks the `ADO_ADDRESSES` map to verify the component exists. In doing this I noticed a bug where duplicate mission components were not being invalidated on instantiation which I fixed by adding a default value into the `ADO_ADDRESSES` map when the component is initially added.

# Testing

## Unit/Integration tests
Were any unit or integration tests written for this change? If not, state why.

## On-chain tests
I tested that instantiation still works for a mission in which two components reference each other. 
https://terrasco.pe/testnet/tx/7E88C59948B4CB5FF79E429A7235230ED7A1B700D3E96A5E05C20166892D6B93

I also tested a case with an invalid token name. I can't show the transaction but I got this error:
```
failed to execute message; message index: 0: dispatch: reply: dispatch: reply: Generic error: dispatch: Invalid component: asdf: execute wasm contract failed: reply wasm contract failed: invalid request
```

# Future work
We should add this logic to every ADO that uses `AndrAddress` on instantiate. I these are the only two for now. 