### PR TITLE
CU-28uxh1c | Add proper display for errors that have parameters

### DIFF
--- a/packages/common/src/error.rs
+++ b/packages/common/src/error.rs
@@ -196,7 +196,7 @@ pub enum ContractError {
     #[error("Invalid png header")]
     InvalidPngHeader {},
     // END CW20 ERRORS
-    #[error("Invalid Module")]
+    #[error("Invalid Module, {msg:?}")]
     InvalidModule { msg: Option<String> },
 
     #[error("UnsupportedOperation")]
@@ -280,16 +280,16 @@ pub enum ContractError {
     #[error("Cannot mint after sale conducted")]
     CannotMintAfterSaleConducted {},
 
-    #[error("Not implemented")]
+    #[error("Not implemented: {msg:?}")]
     NotImplemented { msg: Option<String> },
 
-    #[error("Invalid Strategy")]
+    #[error("Invalid Strategy: {strategy}")]
     InvalidStrategy { strategy: String },
 
     #[error("Invalid Query")]
     InvalidQuery {},
 
-    #[error("Invalid Withdrawal")]
+    #[error("Invalid Withdrawal: {msg:?}")]
     InvalidWithdrawal { msg: Option<String> },
 
     #[error("Airdrop stage {stage} expired at {expiration}")]
@@ -333,6 +333,7 @@ pub enum ContractError {
 
     #[error("Invalid deposit/withdraw window")]
     InvalidWindow {},
+
     #[error("Duplicate tokens")]
     DuplicateTokens {},
 


### PR DESCRIPTION
# Motivation
Currently a lot of very important error info is lost when the error type is transformed into a string. 

# Implementation
To display types that don't implement the `Display` trait we need to add the `:?`. This is analogous to printing in debug mode. I feel like we should just replace all of the `Option<String>` with `String` as I don't see a scenario where we would opt to provide LESS information to the user. 

# Testing

## Unit/Integration tests
None needed.

## On-chain tests
None needed.

# Future work
We may decide to change `Option<String>` to `String` which would require another change to this file. 