### PR TITLE
Allow operators to update code ids in Factory ADO

### DIFF
--- a/contracts/andromeda_factory/src/state.rs
+++ b/contracts/andromeda_factory/src/state.rs
@@ -6,7 +6,7 @@ use cw_storage_plus::Map;
 
 // pub const CONFIG: Item<Config> = Item::new("config");
 pub const SYM_ADDRESS: Map<String, String> = Map::new("address");
-pub const CODE_ID: Map<String, u64> = Map::new("code_id");
+pub const CODE_ID: Map<&str, u64> = Map::new("code_id");
 
 // #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 // pub struct Config {
@@ -14,15 +14,11 @@ pub const CODE_ID: Map<String, u64> = Map::new("code_id");
 //     pub receipt_code_id: u64,
 //     pub address_list_code_id: u64,
 // }
-pub fn store_code_id(
-    storage: &mut dyn Storage,
-    code_id_key: String,
-    code_id: u64,
-) -> StdResult<()> {
+pub fn store_code_id(storage: &mut dyn Storage, code_id_key: &str, code_id: u64) -> StdResult<()> {
     CODE_ID.save(storage, code_id_key, &code_id)
 }
 
-pub fn read_code_id(storage: &dyn Storage, code_id_key: String) -> StdResult<u64> {
+pub fn read_code_id(storage: &dyn Storage, code_id_key: &str) -> StdResult<u64> {
     CODE_ID.load(storage, code_id_key)
 }
 //


### PR DESCRIPTION
# Motivation
Once we have more permanent instances of these contracts on testnet and later mainnet, we want to allow multiple team members to be able to update important data, like code ids.

# Implementation
I just updated the permissions to `owner_or_operator` from `owner`. I also cleaned up a bit of related code.

# Testing

## Unit/Integration tests
I added a test for this change, as well as a test checking that unauthorized users could not update the code id (this was missing for some reason).

## On-chain tests
No, as this was a simple permissions change which we have made before with no problems. 

# Future work
Factory will need to be updated in the future for ADOP related reasons. 