### PR TITLE
CU-282q1ge | Replace Uint128 in WithdrawalType::Percentage with Decimal

### DIFF
--- a/contracts/andromeda_anchor/src/testing/tests.rs
+++ b/contracts/andromeda_anchor/src/testing/tests.rs
@@ -2,7 +2,7 @@ use cosmwasm_bignumber::{Decimal256, Uint256};
 use cosmwasm_std::{
     attr, coin, coins, from_binary,
     testing::{mock_env, mock_info},
-    to_binary, BankMsg, Coin, ContractResult, CosmosMsg, DepsMut, Reply, Response, SubMsg,
+    to_binary, BankMsg, Coin, ContractResult, CosmosMsg, Decimal, DepsMut, Reply, Response, SubMsg,
     SubMsgExecutionResponse, Uint128, WasmMsg,
 };
 
@@ -487,7 +487,7 @@ fn test_withdraw_percent() {
     let msg = ExecuteMsg::AndrReceive(AndromedaMsg::Withdraw {
         recipient: Some(Recipient::Addr(recipient.to_owned())),
         tokens_to_withdraw: Some(vec![Withdrawal {
-            withdrawal_type: Some(WithdrawalType::Percentage(50u128.into())),
+            withdrawal_type: Some(WithdrawalType::Percentage(Decimal::percent(50))),
             token: "uusd".to_string(),
         }]),
     });
@@ -531,7 +531,7 @@ fn test_withdraw_invalid_percent() {
     let msg = ExecuteMsg::AndrReceive(AndromedaMsg::Withdraw {
         recipient: Some(Recipient::Addr(recipient.to_owned())),
         tokens_to_withdraw: Some(vec![Withdrawal {
-            withdrawal_type: Some(WithdrawalType::Percentage(101u128.into())),
+            withdrawal_type: Some(WithdrawalType::Percentage(Decimal::percent(101))),
             token: "uusd".to_string(),
         }]),
     });

--- a/contracts/andromeda_vault/src/contract.rs
+++ b/contracts/andromeda_vault/src/contract.rs
@@ -269,7 +269,7 @@ pub fn withdraw_vault(
                             msg: Some("Percent must be non-zero".to_string()),
                         },
                     )?;
-                    let amount = balance.multiply_ratio(percent, 100u128);
+                    let amount = balance * percent;
                     withdrawal_amount.push(coin(amount.u128(), denom.clone()));
                     BALANCES.save(
                         deps.storage,

--- a/contracts/andromeda_vault/src/testing/mod.rs
+++ b/contracts/andromeda_vault/src/testing/mod.rs
@@ -18,7 +18,7 @@ use common::{
 use cosmwasm_std::{
     coin, from_binary,
     testing::{mock_dependencies, mock_env, mock_info},
-    to_binary, wasm_execute, BankMsg, Coin, CosmosMsg, DepsMut, Env, MessageInfo, ReplyOn,
+    to_binary, wasm_execute, BankMsg, Coin, CosmosMsg, Decimal, DepsMut, Env, MessageInfo, ReplyOn,
     Response, SubMsg, Uint128, WasmMsg,
 };
 
@@ -400,7 +400,7 @@ fn test_withdraw_invalid_withdrawals() {
         recipient: None,
         withdrawals: vec![Withdrawal {
             token: "uusd".to_string(),
-            withdrawal_type: Some(WithdrawalType::Percentage(Uint128::zero())),
+            withdrawal_type: Some(WithdrawalType::Percentage(Decimal::zero())),
         }],
         strategy: None,
     };
@@ -509,7 +509,7 @@ fn test_withdraw_single_no_strategy_percentage() {
         recipient: None,
         withdrawals: vec![Withdrawal {
             token: "uusd".to_string(),
-            withdrawal_type: Some(WithdrawalType::Percentage(Uint128::from(50u128))),
+            withdrawal_type: Some(WithdrawalType::Percentage(Decimal::percent(50))),
         }],
         strategy: None,
     };
@@ -596,7 +596,7 @@ fn test_withdraw_multi_no_strategy_mixed() {
             },
             Withdrawal {
                 token: "uluna".to_string(),
-                withdrawal_type: Some(WithdrawalType::Percentage(Uint128::from(100u128))),
+                withdrawal_type: Some(WithdrawalType::Percentage(Decimal::one())),
             },
         ],
         strategy: None,
@@ -650,11 +650,11 @@ fn test_withdraw_multi_no_strategy_recipient() {
             },
             Withdrawal {
                 token: "uusd".to_string(),
-                withdrawal_type: Some(WithdrawalType::Percentage(Uint128::from(100u128))),
+                withdrawal_type: Some(WithdrawalType::Percentage(Decimal::one())),
             },
             Withdrawal {
                 token: "uluna".to_string(),
-                withdrawal_type: Some(WithdrawalType::Percentage(Uint128::from(100u128))),
+                withdrawal_type: Some(WithdrawalType::Percentage(Decimal::one())),
             },
         ],
         strategy: None,

--- a/packages/common/src/withdraw.rs
+++ b/packages/common/src/withdraw.rs
@@ -1,5 +1,5 @@
 use crate::{error::ContractError, require};
-use cosmwasm_std::Uint128;
+use cosmwasm_std::{Decimal, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -13,7 +13,7 @@ pub struct Withdrawal {
 #[serde(rename_all = "snake_case")]
 pub enum WithdrawalType {
     Amount(Uint128),
-    Percentage(Uint128),
+    Percentage(Decimal),
 }
 
 impl Withdrawal {
@@ -23,8 +23,8 @@ impl Withdrawal {
             None => Ok(balance),
             Some(withdrawal_type) => match withdrawal_type {
                 WithdrawalType::Percentage(percent) => {
-                    require(percent <= 100u128.into(), ContractError::InvalidRate {})?;
-                    Ok(balance.multiply_ratio(percent, 100u128))
+                    require(percent <= Decimal::one(), ContractError::InvalidRate {})?;
+                    Ok(balance * percent)
                 }
                 WithdrawalType::Amount(amount) => {
                     require(
@@ -58,7 +58,7 @@ mod tests {
     fn test_get_amount_percentage() {
         let withdrawal = Withdrawal {
             token: "token".to_string(),
-            withdrawal_type: Some(WithdrawalType::Percentage(10u128.into())),
+            withdrawal_type: Some(WithdrawalType::Percentage(Decimal::percent(10))),
         };
         let balance = Uint128::from(100u128);
         assert_eq!(10u128, withdrawal.get_amount(balance).unwrap().u128());
@@ -68,7 +68,7 @@ mod tests {
     fn test_get_amount_invalid_percentage() {
         let withdrawal = Withdrawal {
             token: "token".to_string(),
-            withdrawal_type: Some(WithdrawalType::Percentage(101u128.into())),
+            withdrawal_type: Some(WithdrawalType::Percentage(Decimal::percent(101))),
         };
         let balance = Uint128::from(100u128);
         assert_eq!(


### PR DESCRIPTION
# Motivation
As with previous similar changes we want to completely move to representing percentages with the `Decimal` type. 

# Implementation
As usual I replaced the type and modified tests. 

# Testing

## Unit/Integration tests
Existing tests were modified. 

## On-chain tests
None necessary. 

# Future work
N/A