### PR TITLE
CU-2914c0w | Crowdfund: Allow ending sale early if max tokens sold is reached

### DIFF
--- a/contracts/andromeda_crowdfund/src/contract.rs
+++ b/contracts/andromeda_crowdfund/src/contract.rs
@@ -1,6 +1,6 @@
 use crate::state::{
-    get_available_tokens, Config, Purchase, State, AVAILABLE_TOKENS, CONFIG, PURCHASES,
-    SALE_CONDUCTED, STATE,
+    get_available_tokens, Config, Purchase, State, AVAILABLE_TOKENS, CONFIG,
+    NUMBER_OF_TOKENS_AVAILABLE, PURCHASES, SALE_CONDUCTED, STATE,
 };
 use ado_base::ADOContract;
 use andromeda_protocol::{
@@ -47,6 +47,7 @@ pub fn instantiate(
         },
     )?;
     SALE_CONDUCTED.save(deps.storage, &false)?;
+    NUMBER_OF_TOKENS_AVAILABLE.save(deps.storage, &Uint128::zero())?;
     ADOContract::default().instantiate(
         deps.storage,
         deps.api,
@@ -214,6 +215,8 @@ fn mint(
     if mint_msg.owner == crowdfund_contract {
         // Mark token as available to purchase in next sale.
         AVAILABLE_TOKENS.save(storage, &mint_msg.token_id, &true)?;
+        let current_number = NUMBER_OF_TOKENS_AVAILABLE.load(storage)?;
+        NUMBER_OF_TOKENS_AVAILABLE.save(storage, &(current_number + Uint128::new(1)))?;
     }
     Ok(Response::new()
         .add_attribute("action", "mint")
@@ -439,6 +442,7 @@ fn purchase_tokens(
         encode_binary(&"")?,
     )?;
 
+    let mut current_number = NUMBER_OF_TOKENS_AVAILABLE.load(storage)?;
     for token_id in token_ids {
         let remaining_amount = remainder.try_get_coin()?;
 
@@ -459,7 +463,9 @@ fn purchase_tokens(
         purchases.push(purchase);
 
         AVAILABLE_TOKENS.remove(storage, &token_id);
+        current_number -= Uint128::new(1);
     }
+    NUMBER_OF_TOKENS_AVAILABLE.save(storage, &current_number)?;
 
     // CHECK :: User has sent enough to cover taxes.
     let required_payment = Coin {
@@ -511,8 +517,10 @@ fn execute_end_sale(
     let state = STATE.may_load(deps.storage)?;
     require(state.is_some(), ContractError::NoOngoingSale {})?;
     let state = state.unwrap();
+    let number_of_tokens_available = NUMBER_OF_TOKENS_AVAILABLE.load(deps.storage)?;
     require(
-        state.expiration.is_expired(&env.block),
+        // If all tokens have been sold the sale can be ended too.
+        state.expiration.is_expired(&env.block) || number_of_tokens_available.is_zero(),
         ContractError::SaleNotEnded {},
     )?;
     if state.amount_sold < state.min_tokens_sold {
@@ -556,7 +564,7 @@ fn issue_refunds_and_burn_tokens(
 
     if burn_msgs.is_empty() && purchases.is_empty() {
         // When all tokens have been burned and all purchases have been refunded, the sale is over.
-        STATE.remove(deps.storage);
+        clear_state(deps.storage)?;
     }
 
     Ok(Response::new()
@@ -604,7 +612,7 @@ fn transfer_tokens_and_send_funds(
         if burn_msgs.is_empty() {
             // When burn messages are empty, we have finished the sale, which is represented by
             // having no State.
-            STATE.remove(deps.storage);
+            clear_state(deps.storage)?;
         } else {
             resp = resp.add_messages(burn_msgs);
         }
@@ -755,6 +763,13 @@ fn get_burn_messages(
             }))
         })
         .collect()
+}
+
+fn clear_state(storage: &mut dyn Storage) -> Result<(), ContractError> {
+    STATE.remove(storage);
+    NUMBER_OF_TOKENS_AVAILABLE.save(storage, &Uint128::zero())?;
+
+    Ok(())
 }
 
 fn query_tokens(

--- a/contracts/andromeda_crowdfund/src/state.rs
+++ b/contracts/andromeda_crowdfund/src/state.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 /// The config.
 pub const CONFIG: Item<Config> = Item::new("config");
 
-/// The number of
+/// The number of tokens available for sale.
 pub const NUMBER_OF_TOKENS_AVAILABLE: Item<Uint128> = Item::new("number_of_tokens_available");
 
 /// Sale started if and only if STATE.may_load is Some and !duration.is_expired()

--- a/contracts/andromeda_crowdfund/src/state.rs
+++ b/contracts/andromeda_crowdfund/src/state.rs
@@ -8,6 +8,9 @@ use serde::{Deserialize, Serialize};
 /// The config.
 pub const CONFIG: Item<Config> = Item::new("config");
 
+/// The number of
+pub const NUMBER_OF_TOKENS_AVAILABLE: Item<Uint128> = Item::new("number_of_tokens_available");
+
 /// Sale started if and only if STATE.may_load is Some and !duration.is_expired()
 pub const STATE: Item<State> = Item::new("state");
 

--- a/contracts/andromeda_crowdfund/src/testing/tests.rs
+++ b/contracts/andromeda_crowdfund/src/testing/tests.rs
@@ -1611,6 +1611,58 @@ fn test_end_sale_single_purchase() {
 }
 
 #[test]
+fn test_end_sale_all_tokens_sold() {
+    let mut deps = mock_dependencies_custom(&[]);
+    init(deps.as_mut(), None);
+
+    STATE
+        .save(
+            deps.as_mut().storage,
+            &State {
+                // Sale has not expired yet.
+                expiration: Expiration::AtHeight(mock_env().block.height + 1),
+                price: coin(100, "uusd"),
+                min_tokens_sold: Uint128::from(1u128),
+                max_amount_per_wallet: 5,
+                amount_sold: Uint128::from(1u128),
+                amount_to_send: Uint128::from(100u128),
+                amount_transferred: Uint128::zero(),
+                recipient: Recipient::Addr("recipient".to_string()),
+            },
+        )
+        .unwrap();
+
+    PURCHASES
+        .save(
+            deps.as_mut().storage,
+            "A",
+            &vec![Purchase {
+                token_id: MOCK_TOKENS_FOR_SALE[0].to_owned(),
+                purchaser: "A".to_string(),
+                tax_amount: Uint128::zero(),
+                msgs: vec![],
+            }],
+        )
+        .unwrap();
+
+    NUMBER_OF_TOKENS_AVAILABLE
+        .save(deps.as_mut().storage, &Uint128::zero())
+        .unwrap();
+
+    let msg = ExecuteMsg::EndSale { limit: None };
+    let info = mock_info("anyone", &[]);
+    let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    assert_eq!(
+        Response::new()
+            .add_attribute("action", "transfer_tokens_and_send_funds")
+            // Burn tokens that were not purchased
+            .add_message(get_transfer_message(MOCK_TOKENS_FOR_SALE[0], "A")),
+        res
+    );
+}
+
+#[test]
 fn test_end_sale_limit_zero() {
     let mut deps = mock_dependencies_custom(&[]);
     init(deps.as_mut(), None);

--- a/contracts/andromeda_crowdfund/src/testing/tests.rs
+++ b/contracts/andromeda_crowdfund/src/testing/tests.rs
@@ -1,6 +1,9 @@
 use crate::{
     contract::{execute, instantiate, query, MAX_MINT_LIMIT},
-    state::{Config, Purchase, State, AVAILABLE_TOKENS, CONFIG, PURCHASES, SALE_CONDUCTED, STATE},
+    state::{
+        Config, Purchase, State, AVAILABLE_TOKENS, CONFIG, NUMBER_OF_TOKENS_AVAILABLE, PURCHASES,
+        SALE_CONDUCTED, STATE,
+    },
     testing::mock_querier::{
         mock_dependencies_custom, MOCK_ADDRESSLIST_CONTRACT, MOCK_CONDITIONS_MET_CONTRACT,
         MOCK_CONDITIONS_NOT_MET_CONTRACT, MOCK_MISSION_CONTRACT, MOCK_RATES_CONTRACT,
@@ -355,6 +358,13 @@ fn test_mint_multiple_successful() {
 
     assert!(AVAILABLE_TOKENS.has(deps.as_ref().storage, "token_id1"));
     assert!(AVAILABLE_TOKENS.has(deps.as_ref().storage, "token_id2"));
+
+    assert_eq!(
+        NUMBER_OF_TOKENS_AVAILABLE
+            .load(deps.as_ref().storage)
+            .unwrap(),
+        Uint128::new(2)
+    );
 }
 
 #[test]
@@ -726,6 +736,10 @@ fn test_purchase_not_enough_for_tax() {
 
     mint(deps.as_mut(), MOCK_TOKENS_FOR_SALE[0]).unwrap();
 
+    NUMBER_OF_TOKENS_AVAILABLE
+        .save(deps.as_mut().storage, &Uint128::new(1))
+        .unwrap();
+
     STATE
         .save(
             deps.as_mut().storage,
@@ -754,6 +768,10 @@ fn test_purchase_not_enough_for_tax() {
     AVAILABLE_TOKENS
         .save(deps.as_mut().storage, MOCK_TOKENS_FOR_SALE[0], &true)
         .unwrap();
+    NUMBER_OF_TOKENS_AVAILABLE
+        .save(deps.as_mut().storage, &Uint128::new(1))
+        .unwrap();
+
     let msg = ExecuteMsg::PurchaseByTokenId {
         token_id: MOCK_TOKENS_FOR_SALE[0].to_owned(),
     };
@@ -847,6 +865,12 @@ fn test_purchase_by_token_id() {
     assert_eq!(state, STATE.load(deps.as_ref().storage).unwrap());
 
     assert!(!AVAILABLE_TOKENS.has(deps.as_ref().storage, MOCK_TOKENS_FOR_SALE[0]));
+    assert_eq!(
+        NUMBER_OF_TOKENS_AVAILABLE
+            .load(deps.as_ref().storage)
+            .unwrap(),
+        Uint128::new(1)
+    );
 
     // Purchase a second one.
     let msg = ExecuteMsg::PurchaseByTokenId {
@@ -1022,6 +1046,13 @@ fn test_multiple_purchases() {
     state.amount_sold += Uint128::from(1u128);
     assert_eq!(state, STATE.load(deps.as_ref().storage).unwrap());
 
+    assert_eq!(
+        NUMBER_OF_TOKENS_AVAILABLE
+            .load(deps.as_ref().storage)
+            .unwrap(),
+        Uint128::zero()
+    );
+
     // User 2 tries to purchase again.
     let msg = ExecuteMsg::Purchase {
         number_of_tokens: None,
@@ -1101,6 +1132,9 @@ fn test_end_sale_not_expired() {
         recipient: Recipient::Addr("recipient".to_string()),
     };
     STATE.save(deps.as_mut().storage, &state).unwrap();
+    NUMBER_OF_TOKENS_AVAILABLE
+        .save(deps.as_mut().storage, &Uint128::new(1))
+        .unwrap();
 
     let msg = ExecuteMsg::EndSale { limit: None };
     let info = mock_info("anyone", &[]);
@@ -1142,6 +1176,13 @@ fn test_integration_conditions_not_met() {
         let _res = mint(deps.as_mut(), token_id).unwrap();
         assert!(AVAILABLE_TOKENS.has(deps.as_ref().storage, token_id));
     }
+
+    assert_eq!(
+        NUMBER_OF_TOKENS_AVAILABLE
+            .load(deps.as_ref().storage)
+            .unwrap(),
+        Uint128::new(7)
+    );
 
     let msg = ExecuteMsg::StartSale {
         expiration: Expiration::AtHeight(mock_env().block.height + 1),
@@ -1215,6 +1256,13 @@ fn test_integration_conditions_not_met() {
     assert!(!AVAILABLE_TOKENS.has(deps.as_ref().storage, MOCK_TOKENS_FOR_SALE[2]));
     assert!(!AVAILABLE_TOKENS.has(deps.as_ref().storage, MOCK_TOKENS_FOR_SALE[3]));
 
+    assert_eq!(
+        NUMBER_OF_TOKENS_AVAILABLE
+            .load(deps.as_ref().storage)
+            .unwrap(),
+        Uint128::new(3)
+    );
+
     let mut env = mock_env();
     env.block.height += 1;
 
@@ -1280,6 +1328,12 @@ fn test_integration_conditions_not_met() {
     deps.querier.tokens_left_to_burn = 0;
     let _res = execute(deps.as_mut(), env, info, msg).unwrap();
     assert!(STATE.may_load(deps.as_mut().storage).unwrap().is_none());
+    assert_eq!(
+        NUMBER_OF_TOKENS_AVAILABLE
+            .load(deps.as_ref().storage)
+            .unwrap(),
+        Uint128::zero()
+    );
 }
 
 #[test]
@@ -1501,6 +1555,12 @@ fn test_integration_conditions_met() {
     deps.querier.tokens_left_to_burn = 0;
     let _res = execute(deps.as_mut(), env, info, msg).unwrap();
     assert!(STATE.may_load(deps.as_mut().storage).unwrap().is_none());
+    assert_eq!(
+        NUMBER_OF_TOKENS_AVAILABLE
+            .load(deps.as_ref().storage)
+            .unwrap(),
+        Uint128::zero()
+    );
 }
 
 #[test]
@@ -1569,6 +1629,9 @@ fn test_end_sale_limit_zero() {
                 recipient: Recipient::Addr("recipient".to_string()),
             },
         )
+        .unwrap();
+    NUMBER_OF_TOKENS_AVAILABLE
+        .save(deps.as_mut().storage, &Uint128::new(1))
         .unwrap();
 
     PURCHASES


### PR DESCRIPTION
# Motivation
It doesn't really make sense to wait out the full duration of a sale if all of the tokens are sold out earlier. This change allows sales to be ended if the duration of the sale has elapsed OR all of the available tokens have been sold. 

# Implementation
I wanted to use `State` at first but I realized that `State` is not defined before a sale starts (for good reason). Therefore, I created a new storage item `NUMBER_OF_TOKENS_AVAILABLE: Item<Uint128>`. This number gets incremented each time a token gets minted for sale and gets decremented each time a token is purchased. The condition for ending sale was modified to `sale_is_expired || number_of_tokens_available == 0`. We can't really use the `AVAILABLE_TOKENS` map to calculate the number left as we would need to iterate over the entries to get the count which is inefficient. 

# Testing

## Unit/Integration tests
I added a test for this logic and updated existing tests to ensure that `NUMBER_OF_TOKENS_AVAILABLE` was correctly updated. 

## On-chain tests
[1. Mint 2 tokens](https://terrasco.pe/testnet/tx/CD25B6470BA7D7D308B655B8E002D98CB3A0175D0524EBF84CF5E2D7604EBDAC)

[2. Start sale (ends a long time from start and min sold 2 and max per wallet 2)](https://terrasco.pe/testnet/tx/9AB8CA9B3F4ACEE8C3E504B953437B72EDB446B546D0E67022DB7DE332729259)

[3. User purchases 2 tokens](https://terrasco.pe/testnet/tx/FB532345D6314695B43552C175F4E984E46C5D8BA1A1EFAC9F9B6585BB7993E1)

[4. User ends sale 1](https://terrasco.pe/testnet/tx/FB532345D6314695B43552C175F4E984E46C5D8BA1A1EFAC9F9B6585BB7993E1)

[5. User ends sale 2](https://terrasco.pe/testnet/tx/98D76F5F1BDF5760B2E57AEBE3EBB8931DD81CE15AA6F6FA5500064E8A433668)

# Future work
n/a
